### PR TITLE
Make waf accept GNU-compatible options

### DIFF
--- a/wscript
+++ b/wscript
@@ -10,6 +10,7 @@ subdirs = 'src'
 def options(opt):
   opt.load('compiler_cxx')
   opt.load('unittest_gtest')
+  opt.load('gnu_dirs')
 
   opt.add_option('--enable-zookeeper',
                  action='store_true', default=False, # dest='nozk',
@@ -30,6 +31,7 @@ def configure(conf):
 
   conf.load('compiler_cxx')
   conf.load('unittest_gtest')
+  conf.load('gnu_dirs')
 
   conf.check_cxx(lib = 'msgpack')
   conf.check_cxx(lib = 'dl')


### PR DESCRIPTION
The correct path to install shared libraries is different among platforms (`lib`, `lib32`, `lib64`, etc.)
However, as waf cannot specify the library directory, all `libjuba*.so` goes to `${PREFIX}/lib` on every platform.

This patch fixes the problem by loading gnu_dirs tool in wscript, so that users can manually specify the library installation path like `--libdir=${PREFIX}/lib64`.

http://waf.googlecode.com/svn/docs/apidocs/tools/gnu_dirs.html

This makes packaging much, much easier :)
