### PR TITLE
Hash feature keys: fixes #67

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ preparing Release 0.3.3
 
 Improvements
   - Jubatus loads plugin from default directory (#57)
+  - Add hash_max_size option to learn in fixed-size memory (#67)
 
 Release 0.3.2 2012/9/21
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/fv_converter/converter_config.cpp
+++ b/src/fv_converter/converter_config.cpp
@@ -211,6 +211,12 @@ static void init_num_rules(const vector<num_rule>& num_rules,
 
 void initialize_converter(const converter_config& config,
                           datum_to_fv_converter& conv) {
+  if (config.hash_max_size.bool_test() && *config.hash_max_size.get() <= 0) {
+    stringstream msg;
+    msg << "hash_max_size must be positive, but is " << *config.hash_max_size.get();
+    throw JUBATUS_EXCEPTION(converter_exception(msg.str()));
+  }
+
   map<string, string_filter_ptr> string_filters;
   init_string_filter_types(config.string_filter_types, string_filters);
   map<string, num_filter_ptr> num_filters;
@@ -225,6 +231,10 @@ void initialize_converter(const converter_config& config,
   init_num_filter_rules(config.num_filter_rules, num_filters, conv);
   init_string_rules(config.string_rules, splitters, conv);
   init_num_rules(config.num_rules, num_features, conv);
+
+  if (config.hash_max_size.bool_test()) {
+    conv.set_hash_max_size(*config.hash_max_size.get());
+  }
 }
 
 }

--- a/src/fv_converter/converter_config.hpp
+++ b/src/fv_converter/converter_config.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <map>
 #include <pficommon/data/serialization.h>
+#include <pficommon/data/optional.h>
 
 #include <pficommon/network/mprpc.h>
 #include <msgpack.hpp>
@@ -93,6 +94,8 @@ struct converter_config {
   std::map<std::string, param_t> num_types;
   std::vector<num_rule> num_rules;
 
+  pfi::data::optional<int64_t> hash_max_size;
+
   MSGPACK_DEFINE(string_filter_types, string_filter_rules,
                  num_filter_types, num_filter_rules,
                  string_types, string_rules,
@@ -108,7 +111,8 @@ struct converter_config {
         & MEMBER(string_types)
         & MEMBER(string_rules)
         & MEMBER(num_types)
-        & MEMBER(num_rules);
+        & MEMBER(num_rules)
+        & MEMBER(hash_max_size);
   }
 
 };

--- a/src/fv_converter/converter_config_test.cpp
+++ b/src/fv_converter/converter_config_test.cpp
@@ -26,6 +26,7 @@
 #include "converter_config.hpp"
 #include "datum_to_fv_converter.hpp"
 #include "datum.hpp"
+#include "exception.hpp"
 
 using namespace std;
 using namespace jubatus;
@@ -78,4 +79,30 @@ TEST(converter_config, config) {
     cout << e << endl;
     throw;
   }
+}
+
+TEST(converter_config, hash) {
+  converter_config config;
+  num_rule r = {"*", "str"};
+  config.num_rules.push_back(r);
+  config.hash_max_size = 1;
+
+  datum_to_fv_converter conv;
+  initialize_converter(config, conv);
+
+  datum d;
+  d.num_values_.push_back(make_pair("age", 10));
+
+  sfv_t f;
+  conv.convert(d, f);
+
+  EXPECT_EQ("0", f[0].first);
+}
+
+TEST(converter_config, hash_negative) {
+  converter_config config;
+  config.hash_max_size = 0;
+  datum_to_fv_converter conv;
+
+  EXPECT_THROW(initialize_converter(config, conv), converter_exception);
 }

--- a/src/fv_converter/datum_to_fv_converter.cpp
+++ b/src/fv_converter/datum_to_fv_converter.cpp
@@ -17,8 +17,9 @@
 
 #include <cmath>
 
-#include "datum_to_fv_converter.hpp"
+#include <pficommon/data/optional.h>
 
+#include "datum_to_fv_converter.hpp"
 #include "datum.hpp"
 
 #include "space_splitter.hpp"
@@ -30,6 +31,7 @@
 #include "num_filter.hpp"
 #include "exception.hpp"
 #include "weight_manager.hpp"
+#include "feature_hasher.hpp"
 
 #include <iostream>
 
@@ -114,6 +116,8 @@ class datum_to_fv_converter_impl {
   
   weight_manager weights_;
 
+  pfi::data::optional<feature_hasher> hasher_;
+
  public:
   datum_to_fv_converter_impl() 
       : weights_() {
@@ -164,6 +168,10 @@ class datum_to_fv_converter_impl {
     convert_unweighted(datum, fv);
     weights_.update_weight(fv);
 
+    if (hasher_) {
+      hasher_->hash_feature_keys(fv);
+    }
+    
     fv.swap(ret_fv);
   }
 
@@ -211,6 +219,9 @@ class datum_to_fv_converter_impl {
     expect.second.swap(value);
   }
 
+  void set_hash_max_size(uint64_t hash_max_size) {
+    hasher_ = feature_hasher(hash_max_size);
+  }
 
  private:
 
@@ -367,6 +378,7 @@ class datum_to_fv_converter_impl {
       }
     }
   }
+
 };
 
 
@@ -421,6 +433,10 @@ void datum_to_fv_converter::add_weight(const string& key,
 void datum_to_fv_converter::revert_feature(const string& feature,
                                            pair<string, string>& expect) const {
   pimpl_->revert_feature(feature, expect);
+}
+
+void datum_to_fv_converter::set_hash_max_size(uint64_t hash_max_size) {
+  pimpl_->set_hash_max_size(hash_max_size);
 }
 
 }

--- a/src/fv_converter/datum_to_fv_converter.hpp
+++ b/src/fv_converter/datum_to_fv_converter.hpp
@@ -86,6 +86,8 @@ class datum_to_fv_converter {
   void revert_feature(const std::string& feature,
                       std::pair<std::string, std::string>& expect) const;
 
+  void set_hash_max_size(uint64_t hash_max_size);
+
  private:
   pfi::lang::scoped_ptr<datum_to_fv_converter_impl> pimpl_;
 };

--- a/src/fv_converter/datum_to_fv_converter_test.cpp
+++ b/src/fv_converter/datum_to_fv_converter_test.cpp
@@ -343,3 +343,20 @@ TEST(datum_to_fv_converter, recursive_filter) {
   EXPECT_EQ("/age+2@str$22", feature[2].first);
   EXPECT_EQ("/age+5+2@str$27", feature[3].first);
 } 
+
+TEST(datum_to_fv_converter, hasher) {
+  datum_to_fv_converter conv;
+  conv.set_hash_max_size(1);
+  conv.register_num_rule("str",
+                         shared_ptr<key_matcher>(new match_all()),
+                         shared_ptr<num_feature>(new num_string_feature()));
+  datum d;
+  for (int i = 0; i < 10; ++i)
+    d.num_values_.push_back(make_pair("age", i));
+
+  vector<pair<string, float> > feature;
+  conv.convert(d, feature);
+
+  for (size_t i = 0; i < feature.size(); ++i)
+    EXPECT_EQ("0", feature[i].first);
+}

--- a/src/fv_converter/feature_hasher.cpp
+++ b/src/fv_converter/feature_hasher.cpp
@@ -1,0 +1,47 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2011,2012 Preferred Infrastructure and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "feature_hasher.hpp"
+
+#include <pficommon/data/functional_hash.h>
+#include <pficommon/lang/cast.h>
+
+#include "../common/exception.hpp"
+#include "../common/hash.hpp"
+#include "exception.hpp"
+
+using namespace std;
+
+namespace jubatus {
+namespace fv_converter {
+
+feature_hasher::feature_hasher(uint64_t max)
+    : max_size_(max) {
+  if (max == 0) {
+    throw JUBATUS_EXCEPTION(converter_exception("feature max size must be positive"));
+  }
+}
+
+void feature_hasher::hash_feature_keys(sfv_t& fv) const {
+  for (size_t i = 0, size = fv.size(); i < size; ++i) {
+    uint64_t id = hash_util::calc_string_hash(fv[i].first) % max_size_;
+    fv[i].first = pfi::lang::lexical_cast<string>(id);
+  }
+}
+
+}
+}

--- a/src/fv_converter/feature_hasher.hpp
+++ b/src/fv_converter/feature_hasher.hpp
@@ -1,0 +1,37 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2011,2012 Preferred Infrastructure and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#pragma once
+
+#include <stdint.h>
+#include "../common/type.hpp"
+
+namespace jubatus {
+namespace fv_converter {
+
+class feature_hasher {
+ public:
+  feature_hasher(uint64_t max);
+
+  void hash_feature_keys(sfv_t& fv) const;
+
+ private:
+  uint64_t max_size_;
+};
+
+}
+}

--- a/src/fv_converter/feature_hasher_test.cpp
+++ b/src/fv_converter/feature_hasher_test.cpp
@@ -1,0 +1,48 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2011,2012 Preferred Infrastructure and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include <gtest/gtest.h>
+
+#include "feature_hasher.hpp"
+#include "exception.hpp"
+
+using namespace std;
+
+namespace jubatus {
+namespace fv_converter {
+
+TEST(feature_hasher, trivial) {
+  feature_hasher h(100);
+  sfv_t fv;
+  fv.push_back(make_pair("f1", 1.0));
+  fv.push_back(make_pair("f2", 2.0));
+
+  h.hash_feature_keys(fv);
+
+  ASSERT_EQ(2u, fv.size());
+  EXPECT_NE("f1", fv[0].first);
+  EXPECT_EQ(1.0, fv[0].second);
+  EXPECT_NE("f2", fv[1].first);
+  EXPECT_EQ(2.0, fv[1].second);
+}
+
+TEST(feature_hasher, zero) {
+  EXPECT_THROW(feature_hasher(0), converter_exception);
+}
+
+}
+}

--- a/src/fv_converter/wscript
+++ b/src/fv_converter/wscript
@@ -54,6 +54,7 @@ def build(bld):
     'revert.cpp',
     'weight_manager.cpp',
     'keyword_weights.cpp',
+    'feature_hasher.cpp',
     ]
   use = 'PFICOMMON MSGPACK DL jubacommon'
 
@@ -127,6 +128,7 @@ def build(bld):
       'revert_test.cpp',
       'weight_manager_test.cpp',
       'keyword_weights_test.cpp',
+      'feature_hasher_test.cpp',
       ]
   test_use = 'PFICOMMON MSGPACK jubaconverter'
 


### PR DESCRIPTION
Hash all feature keys and use fixed number of features forcedly. Hashing may cause decrease of accuracy.
This configuration is given by optional field in `converter_config` object. So, backward compatibility is kept.
