### PR TITLE
fix #122: remove mixable_cast

### DIFF
--- a/src/framework/mixable.hpp
+++ b/src/framework/mixable.hpp
@@ -135,14 +135,5 @@ private:
 
 };
 
-template <typename Mixable>
-mixable0* mixable_cast(Mixable* m){
-  if(m){
-    return reinterpret_cast<mixable0*>(m);
-  }else{
-    throw JUBATUS_EXCEPTION(jubatus::exception::runtime_error("nullpointer exception"));
-  }
-}
-
 } //server
 } //jubatus

--- a/src/server/classifier_serv.cpp
+++ b/src/server/classifier_serv.cpp
@@ -49,12 +49,12 @@ classifier_serv::classifier_serv(const framework::server_argv& a)
   :framework::jubatus_serv(a)
 {
   clsfer_.set_model(make_model());
-  register_mixable(framework::mixable_cast(&clsfer_));
+  register_mixable(&clsfer_);
 
   wm_.wm_ = common::cshared_ptr<fv_converter::weight_manager>(new weight_manager);
   wm_.set_model(wm_.wm_);
 
-  register_mixable(framework::mixable_cast(&wm_));
+  register_mixable(&wm_);
 }
 
 classifier_serv::~classifier_serv() {

--- a/src/server/graph_serv.cpp
+++ b/src/server/graph_serv.cpp
@@ -60,7 +60,7 @@ graph_serv::graph_serv(const framework::server_argv& a)
   common::cshared_ptr<jubatus::graph::graph_base> 
     g(jubatus::graph::create_graph("graph_wo_index"));
   g_.set_model(g);
-  register_mixable(mixable_cast(&g_));
+  register_mixable(&g_);
 }
 graph_serv::~graph_serv()
 {}

--- a/src/server/recommender_serv.cpp
+++ b/src/server/recommender_serv.cpp
@@ -37,7 +37,7 @@ recommender_serv::recommender_serv(const framework::server_argv& a)
   :jubatus_serv(a, a.tmpdir)
 {
   //  rcmdr_.set_model(make_model()); -> we'd have to make it safer
-  register_mixable(mixable_cast(&rcmdr_));
+  register_mixable(&rcmdr_);
 }
 
 recommender_serv::~recommender_serv(){

--- a/src/server/regression_serv.cpp
+++ b/src/server/regression_serv.cpp
@@ -49,7 +49,7 @@ regression_serv::regression_serv(const framework::server_argv & a)
   :jubatus_serv(a)
 {
   gresser_.set_model(make_model());
-  register_mixable(framework::mixable_cast(&gresser_));
+  register_mixable(&gresser_);
 }
 
 regression_serv::~regression_serv() {

--- a/src/server/stat_serv.cpp
+++ b/src/server/stat_serv.cpp
@@ -27,7 +27,7 @@ stat_serv::stat_serv(const framework::server_argv& a)
   config_.window_size = 1024; // default till users call set_config
   common::cshared_ptr<stat::mixable_stat> model(new stat::mixable_stat(config_.window_size));
   stat_.set_model(model);
-  register_mixable(framework::mixable_cast(&stat_));
+  register_mixable(&stat_);
 }
 
 stat_serv::~stat_serv() {

--- a/tools/generator/server_generator.ml
+++ b/tools/generator/server_generator.ml
@@ -110,7 +110,7 @@ let generate_impl s output strees =
   output <<< "{";
   output <<< "  //somemixable* mi = new somemixable;";
   output <<< "  //somemixable_.set_model(mi);";
-  output <<< "  //register_mixable(framework::mixable_cast(mi));";
+  output <<< "  //register_mixable(mi);";
   output <<< "}\n";
 
   output <<< (classname^"::~"^classname^"()");


### PR DESCRIPTION
mixable_cast is replaced by usual upcast of C++.
