### PR TITLE
Use MeCab::Model to make mecab_splitter thread safe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Improvements
   - GCC compilation version <= 4.2 when zookeeper enabled (#60)
   - Experimental support for Clang compilation (#100)
   - Make the timeout smaller in unittest
+  - libmecab_splitter works well in multi-thread environment, and now only support mecab ver. 0.99 or later
+  - word_splitter::split method is now constant
 
 Bugfix
   - #117, #113, #118, #114

--- a/src/fv_converter/character_ngram.cpp
+++ b/src/fv_converter/character_ngram.cpp
@@ -27,7 +27,7 @@ static bool is_begin_of_character(unsigned char c) {
 }
 
 void character_ngram::split(const std::string& string,
-                            std::vector<std::pair<size_t, size_t> >& ret_boundaries) {
+                            std::vector<std::pair<size_t, size_t> >& ret_boundaries) const {
   const size_t len = length_;
   vector<size_t> queue(len);
   size_t p = 0;

--- a/src/fv_converter/character_ngram.hpp
+++ b/src/fv_converter/character_ngram.hpp
@@ -30,7 +30,7 @@ class character_ngram : public word_splitter {
   character_ngram(size_t length) : length_(length) {}
 
   void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries);
+             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
 
  private:
   const size_t length_;

--- a/src/fv_converter/dynamic_splitter.cpp
+++ b/src/fv_converter/dynamic_splitter.cpp
@@ -30,7 +30,7 @@ dynamic_splitter::dynamic_splitter(const std::string& path,
 }
 
 void dynamic_splitter::split(const string& string,
-                             vector<pair<size_t, size_t> >& ret_boundaries) {
+                             vector<pair<size_t, size_t> >& ret_boundaries) const {
   impl_->split(string, ret_boundaries);
 }
 

--- a/src/fv_converter/dynamic_splitter.hpp
+++ b/src/fv_converter/dynamic_splitter.hpp
@@ -32,7 +32,7 @@ class dynamic_splitter : public word_splitter {
                    const std::map<std::string, std::string>& params);
 
   void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries);
+             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
 
  private:
   dynamic_loader loader_;

--- a/src/fv_converter/space_splitter.cpp
+++ b/src/fv_converter/space_splitter.cpp
@@ -28,7 +28,7 @@ using namespace std;
 static const char* SPACES = " \t\f\n\r\v";
 
 void space_splitter::split(const string& string,
-                           vector<pair<size_t, size_t> >& ret_boundaries)
+                           vector<pair<size_t, size_t> >& ret_boundaries) const
 {
   vector<pair<size_t, size_t> > bounds;
 

--- a/src/fv_converter/space_splitter.hpp
+++ b/src/fv_converter/space_splitter.hpp
@@ -25,7 +25,7 @@ namespace fv_converter {
 class space_splitter : public word_splitter {
  public:
   void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries);
+             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
 };
 
 }

--- a/src/fv_converter/test_splitter.cpp
+++ b/src/fv_converter/test_splitter.cpp
@@ -27,7 +27,7 @@ using namespace jubatus::fv_converter;
 class my_splitter : public word_splitter {
  public:
   void split(const std::string& str,
-             std::vector<std::pair<size_t, size_t> >& bounds) {
+             std::vector<std::pair<size_t, size_t> >& bounds) const {
     size_t p = 0;
     while (true) {
       size_t b = str.find_first_not_of(' ', p);

--- a/src/fv_converter/without_split.cpp
+++ b/src/fv_converter/without_split.cpp
@@ -23,7 +23,7 @@ namespace fv_converter {
 using namespace std;
 
 void without_split::split(const std::string& str,
-                          std::vector<std::pair<size_t, size_t> >& ret_boundaries) {
+                          std::vector<std::pair<size_t, size_t> >& ret_boundaries) const {
   ret_boundaries.push_back(make_pair(0, str.size()));
 }
 

--- a/src/fv_converter/without_split.hpp
+++ b/src/fv_converter/without_split.hpp
@@ -27,7 +27,7 @@ namespace fv_converter {
 class without_split : public word_splitter {
  public:
   void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries);
+             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
 };
 
 }

--- a/src/fv_converter/word_splitter.hpp
+++ b/src/fv_converter/word_splitter.hpp
@@ -33,7 +33,7 @@ class word_splitter {
      Each baoudary is represented as a pair of a beginning position and its length.
    */
   virtual void split(const std::string& string,
-                     std::vector<std::pair<size_t, size_t> >& ret_boundaries) = 0;
+                     std::vector<std::pair<size_t, size_t> >& ret_boundaries) const = 0;
 };
 
 }

--- a/src/plugin/fv_converter/mecab_splitter.cpp
+++ b/src/plugin/fv_converter/mecab_splitter.cpp
@@ -21,13 +21,14 @@
 #include "../../fv_converter/util.hpp"
 
 using namespace std;
+using namespace pfi::lang;
 
 namespace jubatus {
 
 using fv_converter::converter_exception;
 
-static MeCab::Tagger* create_mecab_tagger(const char* arg) {
-  MeCab::Tagger* t = MeCab::createTagger(arg);
+static MeCab::Model* create_mecab_model(const char* arg) {
+  MeCab::Model* t = MeCab::createModel(arg);
   if (!t) {
     string msg("cannot make mecab tagger: ");
     msg += MeCab::getTaggerError();
@@ -38,20 +39,32 @@ static MeCab::Tagger* create_mecab_tagger(const char* arg) {
 }
 
 mecab_splitter::mecab_splitter()
-    : tagger_(create_mecab_tagger("")) {
+    : model_(create_mecab_model("")) {
 }
 
 mecab_splitter::mecab_splitter(const char* arg)
-    : tagger_(create_mecab_tagger(arg)) {
+    : model_(create_mecab_model(arg)) {
 }
 
 void mecab_splitter::split(const string& string,
-                           vector<pair<size_t, size_t> >& ret_boundaries) {
-  const MeCab::Node* node = tagger_->parseToNode(string.c_str());
-  if (!node) {
-    // cannot parse the given string
+                           vector<pair<size_t, size_t> >& ret_boundaries) const {
+  scoped_ptr<MeCab::Tagger> tagger(model_->createTagger());
+  if (!tagger) {
+    // cannot create tagger
     return;
   }
+  scoped_ptr<MeCab::Lattice> lattice(model_->createLattice());
+  if (!lattice) {
+    // cannot create lattice
+    return;
+  }
+  lattice->set_sentence(string.c_str());
+  if (!tagger->parse(lattice.get())) {
+    // parse error
+    return;
+  }
+
+  const MeCab::Node* node = lattice->bos_node();
   size_t p = 0;
 
   vector<pair<size_t, size_t> > bounds;

--- a/src/plugin/fv_converter/mecab_splitter.hpp
+++ b/src/plugin/fv_converter/mecab_splitter.hpp
@@ -31,10 +31,10 @@ class mecab_splitter : public fv_converter::word_splitter {
   mecab_splitter(const char* arg);
 
   void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries);
+             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
 
  private:
-  pfi::lang::scoped_ptr<MeCab::Tagger> tagger_;
+  pfi::lang::scoped_ptr<MeCab::Model> model_;
 };
 
 }

--- a/src/plugin/fv_converter/mecab_splitter_test.cpp
+++ b/src/plugin/fv_converter/mecab_splitter_test.cpp
@@ -21,12 +21,16 @@
 #include <map>
 
 #include <pficommon/lang/scoped_ptr.h>
+#include <pficommon/lang/bind.h>
+#include <pficommon/concurrent/thread.h>
 
 #include "mecab_splitter.hpp"
 #include "../../fv_converter/test_util.hpp"
 #include "../../fv_converter/exception.hpp"
 
 using namespace std;
+using namespace pfi::lang;
+using namespace pfi::concurrent;
 
 namespace jubatus {
 
@@ -83,6 +87,33 @@ TEST(mecab_splitter, with_space) {
   exp.push_back(make_pair(11, 9));
 
   PairVectorEquals(exp, bs);
+}
+
+void run(mecab_splitter* m) {
+  vector<pair<size_t, size_t> > exp;
+  exp.push_back(make_pair(0, 6));
+  exp.push_back(make_pair(6, 3));
+  exp.push_back(make_pair(9, 6));
+  exp.push_back(make_pair(15, 6));
+
+  for (int i = 0; i < 1000; ++i) {
+    vector<pair<size_t, size_t> > bs;
+    m->split("本日は晴天なり", bs);
+    PairVectorEquals(exp, bs);
+  }
+}
+
+TEST(mecab_spltter, multi_thread) {
+  // run mecab_splitter in two threads
+  mecab_splitter m;
+  vector<shared_ptr<thread> > ts;
+  for (int i = 0; i < 100; ++i) {
+    ts.push_back(shared_ptr<thread>(new thread(bind(&run ,&m))));
+    ts[i]->start();
+  }
+  for (int i = 0; i < 100; ++i) {
+    ts[i]->join();
+  }
 }
 
 }

--- a/src/plugin/fv_converter/re2_splitter.cpp
+++ b/src/plugin/fv_converter/re2_splitter.cpp
@@ -45,7 +45,7 @@ re2_splitter::re2_splitter(const string& regexp, int group)
 }
 
 void re2_splitter::split(const string& str,
-                         vector<pair<size_t, size_t> >& bounds) {
+                         vector<pair<size_t, size_t> >& bounds) const {
   re2::StringPiece input(str.c_str());
   int groupSize = re_.NumberOfCapturingGroups() + 1;
   vector<re2::StringPiece> words(groupSize);

--- a/src/plugin/fv_converter/re2_splitter.hpp
+++ b/src/plugin/fv_converter/re2_splitter.hpp
@@ -31,7 +31,7 @@ class re2_splitter : jubatus::fv_converter::word_splitter {
  public:
   re2_splitter(const std::string& regexp, int group);
   void split(const std::string& str,
-             std::vector<std::pair<size_t, size_t> >& bounds);
+             std::vector<std::pair<size_t, size_t> >& bounds) const;
  private:
   re2::RE2 re_;
   int group_;

--- a/src/plugin/fv_converter/ux_splitter.cpp
+++ b/src/plugin/fv_converter/ux_splitter.cpp
@@ -40,7 +40,7 @@ ux_splitter::~ux_splitter() {
 }
 
 void ux_splitter::split(const string& string,
-                        vector<pair<size_t, size_t> >& ret_boundaries) {
+                        vector<pair<size_t, size_t> >& ret_boundaries) const {
   vector<pair<size_t, size_t> > bounds;
   for (size_t i = 0; i < string.size(); ++i) {
     size_t len = 0;

--- a/src/plugin/fv_converter/ux_splitter.hpp
+++ b/src/plugin/fv_converter/ux_splitter.hpp
@@ -28,7 +28,7 @@ class ux_splitter : public fv_converter::word_splitter {
   ~ux_splitter();
 
   void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries);
+             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
 
  private:
   ux::Trie trie_;

--- a/src/plugin/fv_converter/wscript
+++ b/src/plugin/fv_converter/wscript
@@ -14,8 +14,16 @@ def options(opt):
 def configure(conf):
   if Options.options.enable_mecab:
     conf.check_cxx(lib = 'mecab',
+                   fragment='''
+#include <mecab.h>
+int main() {
+  MeCab::Model* (*p)(const char*) = MeCab::createModel;
+  &MeCab::Model::createTagger;
+  &MeCab::Model::createLattice;
+}
+''',
                    define_name = 'HAVE_MECAB',
-                   errmsg = 'not found (remove "--enable-mecab" option if not necessary)')
+                   errmsg = 'mecab 0.99 or later is required (remove "--enable-mecab" option if not necessary)')
     
 
   if Options.options.enable_ux:


### PR DESCRIPTION
Previous implementation of mecab_splitter is not thread safe because we used old API of mecab that is not thread safe. I adopt new mecab API supported v. 0.99. I  also make multi-thread test to check the splitter working.
