### PR TITLE
Show error message when servers fail to start: #fix 138

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Improvements
   - Use (document_frequency + 1) to calculate IDF weight to avoid inifinity
 
 Bugfix
-  - #94, #117, #113, #118, #114, #124, #133, #146
+  - #94, #117, #113, #118, #114, #124, #133, #138, #146
 
 Release 0.3.2 2012/9/21
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/framework/keeper.cpp
+++ b/src/framework/keeper.cpp
@@ -47,10 +47,14 @@ keeper::~keeper(){
 int keeper::run()
 {
   try {
-    { LOG(INFO) << "running in port=" << a_.port; }
     jubatus::util::set_exit_on_term();
     jubatus::util::ignore_sigpipe();
-    return this->serv(a_.port, a_.threadnum);
+    if (this->serv(a_.port, a_.threadnum)) {
+      return 0;
+    } else {
+      LOG(ERROR) << "failed starting server: any process using port " << a_.port << "?";
+      return -1;
+    }
   } catch (const jubatus::exception::jubatus_exception& e) {
     std::cout << e.diagnostic_information(true) << std::endl;
     return -1;

--- a/src/framework/server_helper.hpp
+++ b/src/framework/server_helper.hpp
@@ -111,7 +111,6 @@ public:
     }
 
     if (serv.serv(a.port, a.threadnum)) {
-      LOG(INFO) << "running in port=" << a.port;
       return 0;
     } else {
       LOG(ERROR) << "failed starting server: any process using port " << a.port << "?";

--- a/src/framework/server_util.cpp
+++ b/src/framework/server_util.cpp
@@ -138,6 +138,8 @@ namespace jubatus { namespace framework {
     timeout = p.get<int>("timeout");
     z = p.get<std::string>("zookeeper");
     eth = jubatus::util::get_ip("eth0");
+
+    LOG(INFO) << boot_message(jubatus::util::get_program_name());
   };
 
   keeper_argv::keeper_argv():


### PR DESCRIPTION
Print the same message to servers when keeper process fail to start.
