### PR TITLE
Fix #86: use "log_tf" for feature representation.

### DIFF
--- a/src/fv_converter/datum_to_fv_converter.cpp
+++ b/src/fv_converter/datum_to_fv_converter.cpp
@@ -342,7 +342,7 @@ class datum_to_fv_converter_impl {
         return tf;
 
       case LOG_TERM_FREQUENCY:
-        name = "logtf";
+        name = "log_tf";
         return  log(1. + tf);
 
       default:

--- a/src/fv_converter/datum_to_fv_converter_test.cpp
+++ b/src/fv_converter/datum_to_fv_converter_test.cpp
@@ -145,11 +145,11 @@ TEST(datum_to_fv_converter, string_feature) {
   expected.push_back(make_pair("/title$it@space#tf/idf",   3. * idf1));
   expected.push_back(make_pair("/title$.@space#tf/idf",    2. * idf1));
 
-  expected.push_back(make_pair("/name$doc1@space#logtf/idf",  log(2.) * idf1));
-  //expected.push_back(make_pair("/title$this@space#logtf/idf", log(2.) * idf2));
-  //expected.push_back(make_pair("/title$is@space#logtf/idf",   log(3.) * idf2));
-  expected.push_back(make_pair("/title$it@space#logtf/idf",   log(4.) * idf1));
-  expected.push_back(make_pair("/title$.@space#logtf/idf",    log(3.) * idf1));
+  expected.push_back(make_pair("/name$doc1@space#log_tf/idf",  log(2.) * idf1));
+  //expected.push_back(make_pair("/title$this@space#log_tf/idf", log(2.) * idf2));
+  //expected.push_back(make_pair("/title$is@space#log_tf/idf",   log(3.) * idf2));
+  expected.push_back(make_pair("/title$it@space#log_tf/idf",   log(4.) * idf1));
+  expected.push_back(make_pair("/title$.@space#log_tf/idf",    log(3.) * idf1));
 
   //expected.push_back(make_pair("/title$is@ux#tf/bin", 3.));
 


### PR DESCRIPTION
Use "log_tf" instead of "logtf" in feature representation.
This change breaks compatibility of serialization format.
