### PR TITLE
Fix #203: Fix names of variables and functions

### DIFF
--- a/src/server/anomaly.idl
+++ b/src/server/anomaly.idl
@@ -36,8 +36,8 @@
 #-    }
 
 message datum {
-  0: list<tuple<string, string> >  sv
-  1: list<tuple<string, double> >  nv
+  0: list<tuple<string, string> >  string_values
+  1: list<tuple<string, double> >  num_values
 }
 
 service anomaly {
@@ -45,17 +45,17 @@ service anomaly {
   #@random #@analysis #@pass
   string get_config(0: string name) # //@random
 
-  #- clear a point data.
+  #- clear a point.
   #@cht #@update #@all_and
   bool clear_row(0: string name, 1: string id) # //@cht
 
-  #- add a point data.
+  #- add a point.
   #@random #@update #@pass
-  tuple<string, float> add(0: string name, 1: datum d) # //@random
+  tuple<string, float> add(0: string name, 1: datum row) # //@random
 
-  #- update a point with new data.
+  #- update a point.
   #@cht #@update #@pass
-  float update(0: string name, 1: string id, 2: datum d) # //@cht
+  float update(0: string name, 1: string id, 2: datum row) # //@cht
 
   #- clear whole data.
   #@broadcast #@update #@all_and
@@ -63,16 +63,16 @@ service anomaly {
 
   #- calculate an anomaly measure value without adding a point.
   #@random #@analysis #@pass
-  float calc_score(0: string name, 1: datum d) # //@random
+  float calc_score(0: string name, 1: datum row) # //@random
 
   #@broadcast #@analysis #@concat
   list<string>  get_all_rows(0: string name) # //@broadcast
 
   #@broadcast #@update #@all_and
-  bool save(0: string name, 1: string arg1) # //@broadcast
+  bool save(0: string name, 1: string id) # //@broadcast
 
   #@broadcast #@update #@all_and
-  bool load(0: string name, 1: string arg1) # //@broadcast
+  bool load(0: string name, 1: string id) # //@broadcast
 
   #@broadcast #@analysis #@merge
   map<string, map<string, string> >  get_status(0: string name) # //@broadcast

--- a/src/server/classifier.idl
+++ b/src/server/classifier.idl
@@ -14,8 +14,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-type param_t = map<string, string> 
-
 message datum {
   0: list<tuple<string, string> >  string_values
   1: list<tuple<string, double> >  num_values
@@ -23,7 +21,7 @@ message datum {
 
 message estimate_result {
   0: string label
-  1: double prob
+  1: double score
 }
 
 service classifier {

--- a/src/server/graph.idl
+++ b/src/server/graph.idl
@@ -14,10 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-type property = map<string, string> 
-
-message node_info {
-  0: property p
+message node {
+  0: map<string, string>  property
   1: list<ulong>  in_edges
   2: list<ulong>  out_edges
 }
@@ -30,17 +28,17 @@ message preset_query {
   1: list<tuple<string, string> > node_query
 }
 
-message edge_info {
-  0: property p
-  1: string src
-  2: string tgt
+message edge {
+  0: map<string, string> property
+  1: string source
+  2: string target
 }
 
-message shortest_path_req {
-  0: string src
-  1: string tgt
+message shortest_path_query {
+  0: string source
+  1: string target
   2: uint max_hop
-  3: preset_query q
+  3: preset_query query
 }
 
 service graph {
@@ -49,35 +47,35 @@ service graph {
   string create_node(0: string name) # //@cht
 
   #@cht(2) #@update #@pass
-  bool remove_node(0: string name, 1: string nid) # //@cht
+  bool remove_node(0: string name, 1: string node_id) # //@cht
 
   #@cht #@update #@all_and
-  bool update_node(0: string name, 1: string nid, 2: property p) # //@cht
+  bool update_node(0: string name, 1: string node_id, 2: map<string, string> property) # //@cht
 
   #@cht(1) #@nolock #@all_and
-  ulong create_edge(0: string name, 1: string nid, 2: edge_info ei) # //@cht
+  ulong create_edge(0: string name, 1: string node_id, 2: edge e) # //@cht
 
   #@cht #@update #@all_and
-  bool update_edge(0: string name, 1: string nid, 2: ulong eid, 3: edge_info ei) # //@cht
+  bool update_edge(0: string name, 1: string node_id, 2: ulong edge_id, 3: edge e) # //@cht
 
   #@cht #@update #@all_and
-  bool remove_edge(0: string name, 1: string nid, 2: ulong e) # //@cht
+  bool remove_edge(0: string name, 1: string node_id, 2: ulong edge_id) # //@cht
 
   #@random #@analysis #@pass
-  double centrality(0: string name, 1: string nid,
-		    2: int ct, 3: preset_query q) # //@random
+  double centrality(0: string name, 1: string node_id,
+                    2: int centrality_type, 3: preset_query query) # //@random
 
   #@broadcast #@update #@all_and
-  bool add_centrality_query(0: string name, 1: preset_query q)
+  bool add_centrality_query(0: string name, 1: preset_query query)
   #@broadcast #@update #@all_and
-  bool add_shortest_path_query(0: string name, 1: preset_query q)
+  bool add_shortest_path_query(0: string name, 1: preset_query query)
   #@broadcast #@update #@all_and
-  bool remove_centrality_query(0: string name, 1: preset_query q)
+  bool remove_centrality_query(0: string name, 1: preset_query query)
   #@broadcast #@update #@all_and
-  bool remove_shortest_path_query(0: string name, 1: preset_query q)
+  bool remove_shortest_path_query(0: string name, 1: preset_query query)
 
   #@random #@analysis #@pass
-  list<string>  shortest_path(0: string name, 1: shortest_path_req r) # //@random
+  list<string> get_shortest_path(0: string name, 1: shortest_path_query query) # //@random
 
   #@broadcast #@update #@all_and
   bool update_index(0: string name) # //@broadcast
@@ -86,25 +84,25 @@ service graph {
   bool clear(0: string name) # //@broadcast
 
   #@cht #@analysis #@pass
-  node_info get_node(0: string name, 1: string nid) # //@cht
+  node get_node(0: string name, 1: string node_id) # //@cht
 
   #@cht #@analysis #@pass
-  edge_info get_edge(0: string name, 1: string nid, 2: ulong e) # //@cht
+  edge get_edge(0: string name, 1: string node_id, 2: ulong edge_id) # //@cht
 
   #@broadcast #@update #@all_and
-  bool save(0: string name, 1: string arg1)
+  bool save(0: string name, 1: string id)
 
   #@broadcast #@update #@all_and
-  bool load(0: string name, 1: string arg1)
+  bool load(0: string name, 1: string id)
 
   #@broadcast #@analysis #@merge
   map<string, map<string, string> >  get_status(0: string name)
 
   #@internal #@update #@pass
-  bool create_node_here(0: string name, 1: string nid)
+  bool create_node_here(0: string name, 1: string node_id)
   #@internal #@update #@pass
-  bool remove_global_node(0: string name, 1: string nid)
+  bool remove_global_node(0: string name, 1: string node_id)
 
   #@internal #@update #@pass
-  bool create_edge_here(0: string name, 1: ulong eid, 2: edge_info ei)
+  bool create_edge_here(0: string name, 1: ulong edge_id, 2: edge e)
 }

--- a/src/server/recommender.idl
+++ b/src/server/recommender.idl
@@ -30,7 +30,7 @@ service recommender {
   bool clear_row(0: string name, 1: string id) # //@cht
 
   #@cht #@update #@all_and
-  bool update_row(0: string name, 1: string id, 2: datum d) # //@cht
+  bool update_row(0: string name, 1: string id, 2: datum row) # //@cht
 
   #@broadcast #@update #@all_and
   bool clear(0: string name) # //@broadcast
@@ -39,13 +39,13 @@ service recommender {
   datum complete_row_from_id(0: string name, 1: string id) # //@cht
 
   #@random #@analysis #@pass
-  datum complete_row_from_data(0: string name, 1: datum d) # //@random
+  datum complete_row_from_datum(0: string name, 1: datum row) # //@random
 
   #@cht #@analysis #@pass
   similar_result similar_row_from_id(0: string name, 1: string id, 2: uint size) # //@cht
 
   #@random #@analysis #@pass
-  similar_result similar_row_from_data(0: string name, 1: datum data, 2: uint size) # //@random
+  similar_result similar_row_from_datum(0: string name, 1: datum row, 2: uint size) # //@random
 
   #@cht #@analysis #@pass
   datum decode_row(0: string name, 1: string id) # //@cht
@@ -54,10 +54,10 @@ service recommender {
   list<string>  get_all_rows(0: string name) # //@broadcast
 
   #@random #@analysis #@pass
-  float similarity(0: string name, 1: datum lhs, 2:datum rhs) # //@random
+  float calc_similarity(0: string name, 1: datum lhs, 2:datum rhs) # //@random
 
   #@random #@analysis #@pass
-  float l2norm(0: string name, 1: datum d) # //@random
+  float calc_l2norm(0: string name, 1: datum row) # //@random
 
   #@broadcast #@update #@all_and
   bool save(0: string name, 1: string id) # //@broadcast

--- a/src/server/regression.idl
+++ b/src/server/regression.idl
@@ -14,8 +14,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-type param_t = map<string, string> 
-
 message datum {
   0: list<tuple<string, string> >  string_values
   1: list<tuple<string, double> >  num_values
@@ -33,10 +31,10 @@ service regression {
   list<float>  estimate(0: string name, 1: list<datum>  estimate_data) # //@random
 
   #@broadcast #@update #@all_and
-  bool save(0: string name, 1: string arg1) # //@broadcast
+  bool save(0: string name, 1: string id) # //@broadcast
 
   #@broadcast #@update #@all_and
-  bool load(0: string name, 1: string arg1) # //@broadcast
+  bool load(0: string name, 1: string id) # //@broadcast
 
   #@broadcast #@analysis #@merge
   map<string, map<string, string> >  get_status(0: string name) # //@broadcast

--- a/src/server/stat.idl
+++ b/src/server/stat.idl
@@ -20,7 +20,7 @@ service stat {
   string get_config(0: string name)
 
   #@cht(1) #@update #@all_and
-  bool push(0: string name, 1: string key, 2: double val)
+  bool push(0: string name, 1: string key, 2: double value)
 
   #@cht(1) #@analysis #@pass
   double sum(0: string name, 1: string key)
@@ -33,7 +33,7 @@ service stat {
   #@cht(1) #@analysis #@pass
   double entropy(0: string name, 1: string key)
   #@cht(1) #@analysis #@pass
-  double moment(0: string name, 1: string key, 2: int n, 3: double c)
+  double moment(0: string name, 1: string key, 2: int degree, 3: double center)
 
   #@broadcast #@update #@all_and
   bool save(0: string name, 1: string id) # #@broadcast


### PR DESCRIPTION
Fix naming convention:
- change abbreviations to original words
- change variable names to more suitable ones
