### PR TITLE
Accept cast from integer to float

### DIFF
--- a/src/common/jsonconfig/cast.hpp
+++ b/src/common/jsonconfig/cast.hpp
@@ -84,6 +84,20 @@ inline bool check_json_type(json_config_iarchive_cast& js, pfi::text::json::json
   }
   return true;
 }
+
+inline bool check_json_float(json_config_iarchive_cast& js) {
+  if (js.get().type() != pfi::text::json::json::Float
+      && js.get().type() != pfi::text::json::json::Integer) {
+    type_error e(js.get_config().path(), pfi::text::json::json::Float, js.get().type());
+    if (js.trace_error()) {
+      js.push_error(e);
+    } else {
+      throw JUBATUS_EXCEPTION(e);
+    }
+    return false;
+  }
+  return true;
+}
 } // detail
 
 #define GENERATE_CONFIG_SERIALIZE_DEF(typ, json_typ) \
@@ -97,9 +111,18 @@ inline bool check_json_type(json_config_iarchive_cast& js, pfi::text::json::json
 GENERATE_CONFIG_SERIALIZE_DEF(bool, Bool)
 GENERATE_CONFIG_SERIALIZE_DEF(int32_t, Integer)
 GENERATE_CONFIG_SERIALIZE_DEF(int64_t, Integer)
-GENERATE_CONFIG_SERIALIZE_DEF(float, Float)
-GENERATE_CONFIG_SERIALIZE_DEF(double, Float)
 GENERATE_CONFIG_SERIALIZE_DEF(std::string, String)
+
+#define GENERATE_CONFIG_SERIALIZE_FLOAT_DEF(typ) \
+  template <> \
+  inline void serialize(json_config_iarchive_cast& js, typ& v) { \
+    if (detail::check_json_float(js)) { \
+      v = pfi::text::json::json_cast<typ>(js.get()); \
+    } \
+  }
+
+GENERATE_CONFIG_SERIALIZE_FLOAT_DEF(float)
+GENERATE_CONFIG_SERIALIZE_FLOAT_DEF(double)
 
 template <typename T>
 inline void serialize(json_config_iarchive_cast& js, std::vector<T>& vs) {

--- a/src/common/jsonconfig_test.cpp
+++ b/src/common/jsonconfig_test.cpp
@@ -162,6 +162,18 @@ TEST(jsonconfig_cast, int) {
   EXPECT_EQ(1, config_cast<int>(conf));
 }
 
+TEST(jsonconfig_cast, float) {
+  json j(new json_float(1.0));
+  config conf(j);
+  EXPECT_EQ(1.0, config_cast<float>(conf));
+}
+
+TEST(jsonconfig_cast, int_to_float) {
+  json j(new json_integer(1));
+  config conf(j);
+  EXPECT_EQ(1.0, config_cast<float>(conf));
+}
+
 TEST(jsonconfig_cast, string) {
   json j(new json_string("test"));
   config conf(j);


### PR DESCRIPTION
`config_cast` denies cast from `pfi::text::json::json::Integer` to float or double. It is messy as a user need to write "1.0" instead of "1" for float.
This patch accepts both types of configuration.
