### PR TITLE
Convert hyper-parameter of AROW to 1/C

### DIFF
--- a/src/classifier/arow.cpp
+++ b/src/classifier/arow.cpp
@@ -40,7 +40,7 @@ void AROW::train(const sfv_t& sfv, const string& label){
    if (margin >= 1.f) {
     return;
   }
-  float beta = 1.f / (variance + config.C);
+  float beta = 1.f / (variance + 1.f / config.C);
   float alpha = (1.f - margin) * beta; // max(0, 1-margin) = 1-margin 
   update(sfv, alpha, beta, label, incorrect_label);
 }


### PR DESCRIPTION
The meaning of the original hyper-parameter of AROW is different from others.
I modified C to 1/C in AROW, and it works like PA-I.
