### PR TITLE
fix #247 feature with $ goes wrong

### DIFF
--- a/src/fv_converter/revert.cpp
+++ b/src/fv_converter/revert.cpp
@@ -86,7 +86,7 @@ bool revert_string_value(
   if (at == std::string::npos) {
     return false;
   }
-  size_t dollar = f.rfind('$', at);
+  size_t dollar = f.find('$');
   if (dollar == std::string::npos) {
     return false;
   }

--- a/src/fv_converter/revert_test.cpp
+++ b/src/fv_converter/revert_test.cpp
@@ -87,5 +87,21 @@ TEST(revert_feature, trivial) {
   EXPECT_EQ(12345, data.num_values_[1].second);
 }
 
+
+TEST(revert_feature, dollar_mark_onvalue) {
+  fv_converter::datum data;
+  sfv_t fv;
+
+  fv.push_back(std::make_pair("name$do$c1@str#bin/bin", 1.0));
+
+  revert_feature(fv, data);
+
+  ASSERT_EQ(1u, data.string_values_.size());
+  EXPECT_EQ("name", data.string_values_[0].first);
+  EXPECT_EQ("do$c1", data.string_values_[0].second);
+  ASSERT_EQ(0, data.num_values_.size());
+}
+
+
 }  // namespace fv_converter
 }  // namespace jubatus


### PR DESCRIPTION
Value will contain '$', it is harmful. We should fix it.
Key may contain '$' but it is user's setting problem.
We should fix it with another patch or announce to users not to use '$' mark in key.
