### PR TITLE
Refactoring regression/pa.cpp

### DIFF
--- a/src/regression/pa.cpp
+++ b/src/regression/pa.cpp
@@ -26,20 +26,20 @@ namespace regression {
 PA::PA(const config& config, storage::storage_base* storage)
     : regression_base(storage),
       config_(config),
-      sum_(0),
-      sq_sum_(0),
-      count_(0) {
+      sum_(0.f),
+      sq_sum_(0.f),
+      count_(0.f) {
 }
 
 PA::PA(storage::storage_base* storage)
     : regression_base(storage),
-      sum_(0),
-      sq_sum_(0),
-      count_(0) {
+      sum_(0.f),
+      sq_sum_(0.f),
+      count_(0.f) {
 }
 
-static float calc_norm(const sfv_t& fv) {
-  float norm = 0;
+static float squared_norm(const sfv_t& fv) {
+  float norm = 0.f;
   for (size_t i = 0; i < fv.size(); ++i) {
     norm += fv[i].second * fv[i].second;
   }
@@ -51,16 +51,15 @@ void PA::train(const sfv_t& fv, float value) {
   sq_sum_ += value * value;
   count_ += 1;
   float avg = sum_ / count_;
-  float std_dev = sqrt(sq_sum_ / count_ - 2 * avg * sum_ / count_ + avg * avg);
-  float fv_norm = sqrt(calc_norm(fv));
+  float std_dev = sqrt(sq_sum_ / count_ -  avg * avg);
 
   float predict = estimate(fv);
   float error = value - predict;
-  float sign_error = error > 0 ? 1.0f : -1.0f;
+  float sign_error = error > 0.f ? 1.0f : -1.0f;
   float loss = sign_error * error - config_.epsilon * std_dev;
 
-  if (loss > 0) {
-    float coeff = sign_error * std::min(config_.C, loss) / (fv_norm * fv_norm);
+  if (loss > 0.f) {
+    float coeff = sign_error * std::min(config_.C, loss) / squared_norm(fv);
     if (!std::isinf(coeff)) {
       update(fv, coeff);
     }


### PR DESCRIPTION
The details are as follows.
- rename calc_norm to squared_norm, which is used in classifier_base
- remove redundant code
- fix code style(use 0.f for float type)
