### PR TITLE
change the type of some variables from size_t to uint64_t

### DIFF
--- a/src/graph/graph_type.hpp
+++ b/src/graph/graph_type.hpp
@@ -218,14 +218,14 @@ namespace pfi {
 namespace data {
 
 template<> struct hash<jubatus::graph::preset_query> {
-  size_t operator()(const jubatus::graph::preset_query& p) const {
+  uint64_t operator()(const jubatus::graph::preset_query& p) const {
     return update(p.node_query, update(p.edge_query, 14695981039346656037LLU));
   }
 
  private:
-  static size_t update(
+  static uint64_t update(
       const std::vector<std::pair<std::string, std::string> >& q,
-      size_t h) {
+      uint64_t h) {
     for (size_t i = 0; i < q.size(); ++i) {
       h = update(q[i].first, h);
       h = update(q[i].second, h);
@@ -233,7 +233,7 @@ template<> struct hash<jubatus::graph::preset_query> {
     return h;
   }
 
-  static size_t update(const std::string& s, size_t h) {
+  static uint64_t update(const std::string& s, uint64_t h) {
     for (size_t i = 0; i < s.size(); ++i) {
       h *= 1099511628211LLU;
       h ^= s[i];

--- a/src/storage/lsh_index_storage.cpp
+++ b/src/storage/lsh_index_storage.cpp
@@ -125,7 +125,7 @@ string serialize_diff(const lsh_master_table_t& table) {
 }
 
 void retrieve_hit_rows_from_table(
-    size_t hash,
+    uint64_t hash,
     const lsh_table_t& table,
     unordered_set<uint64_t>& cands) {
   lsh_table_t::const_iterator it = table.find(hash);
@@ -425,7 +425,7 @@ void lsh_index_storage::set_mixed_row(
 }
 
 bool lsh_index_storage::retrieve_hit_rows(
-    size_t hash,
+    uint64_t hash,
     size_t ret_num,
     unordered_set<uint64_t>& cands) const {
   retrieve_hit_rows_from_table(hash, lsh_table_diff_, cands);

--- a/src/storage/lsh_index_storage.hpp
+++ b/src/storage/lsh_index_storage.hpp
@@ -107,7 +107,7 @@ class lsh_index_storage : public recommender_storage_base {
       float norm,
       lsh_entry& entry) const;
   bool retrieve_hit_rows(
-      size_t hash,
+      uint64_t hash,
       size_t ret_num,
       pfi::data::unordered_set<uint64_t>& cands) const;
 

--- a/src/storage/lsh_vector.hpp
+++ b/src/storage/lsh_vector.hpp
@@ -82,15 +82,15 @@ namespace data {
 template<>
 class hash<jubatus::storage::lsh_vector> {
  public:
-  size_t operator()(const jubatus::storage::lsh_vector& lv) const {
+  uint64_t operator()(const jubatus::storage::lsh_vector& lv) const {
     const char* p = reinterpret_cast<const char*>(&lv.values_[0]);
     const size_t len = lv.size() * sizeof(lv.values_[0]);
     const char* const end = p + len;
 
-    size_t x = 14695981039346656037ull;
+    uint64_t x = 14695981039346656037ull;
     while (p != end) {
       x *= 1099511628211ull;
-      x ^= static_cast<size_t>(*p++);
+      x ^= static_cast<uint64_t>(*p++);
     }
     return x;
   }


### PR DESCRIPTION
In my 32bit Ubuntu environment, size_t and uint64_t are NOT the same, therefore some tests fail.
This change would not affect the environment where size_t and uint64_t are the same.
