### PR TITLE
add cpp-client get_client() method

### DIFF
--- a/client/anomaly_client.hpp
+++ b/client/anomaly_client.hpp
@@ -21,56 +21,60 @@ class anomaly {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   bool clear_row(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("clear_row", name, id);
     return f.get<bool>();
   }
-  
+
   std::pair<std::string, float> add(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("add", name, row);
     return f.get<std::pair<std::string, float> >();
   }
-  
+
   float update(std::string name, std::string id, datum row) {
     msgpack::rpc::future f = c_.call("update", name, id, row);
     return f.get<float>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   float calc_score(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("calc_score", name, row);
     return f.get<float>();
   }
-  
+
   std::vector<std::string> get_all_rows(std::string name) {
     msgpack::rpc::future f = c_.call("get_all_rows", name);
     return f.get<std::vector<std::string> >();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/client/classifier_client.hpp
+++ b/client/classifier_client.hpp
@@ -21,43 +21,47 @@ class classifier {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   int32_t train(std::string name, std::vector<std::pair<std::string,
        datum> > data) {
     msgpack::rpc::future f = c_.call("train", name, data);
     return f.get<int32_t>();
   }
-  
+
   std::vector<std::vector<estimate_result> > classify(std::string name,
        std::vector<datum> data) {
     msgpack::rpc::future f = c_.call("classify", name, data);
     return f.get<std::vector<std::vector<estimate_result> > >();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/client/graph_client.hpp
+++ b/client/graph_client.hpp
@@ -21,126 +21,130 @@ class graph {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   std::string create_node(std::string name) {
     msgpack::rpc::future f = c_.call("create_node", name);
     return f.get<std::string>();
   }
-  
+
   bool remove_node(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("remove_node", name, node_id);
     return f.get<bool>();
   }
-  
+
   bool update_node(std::string name, std::string node_id, std::map<std::string,
        std::string> property) {
     msgpack::rpc::future f = c_.call("update_node", name, node_id, property);
     return f.get<bool>();
   }
-  
+
   uint64_t create_edge(std::string name, std::string node_id, edge e) {
     msgpack::rpc::future f = c_.call("create_edge", name, node_id, e);
     return f.get<uint64_t>();
   }
-  
+
   bool update_edge(std::string name, std::string node_id, uint64_t edge_id,
        edge e) {
     msgpack::rpc::future f = c_.call("update_edge", name, node_id, edge_id, e);
     return f.get<bool>();
   }
-  
+
   bool remove_edge(std::string name, std::string node_id, uint64_t edge_id) {
     msgpack::rpc::future f = c_.call("remove_edge", name, node_id, edge_id);
     return f.get<bool>();
   }
-  
+
   double get_centrality(std::string name, std::string node_id,
        int32_t centrality_type, preset_query query) {
     msgpack::rpc::future f = c_.call("get_centrality", name, node_id,
          centrality_type, query);
     return f.get<double>();
   }
-  
+
   bool add_centrality_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("add_centrality_query", name, query);
     return f.get<bool>();
   }
-  
+
   bool add_shortest_path_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("add_shortest_path_query", name, query);
     return f.get<bool>();
   }
-  
+
   bool remove_centrality_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("remove_centrality_query", name, query);
     return f.get<bool>();
   }
-  
+
   bool remove_shortest_path_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("remove_shortest_path_query", name, query);
     return f.get<bool>();
   }
-  
+
   std::vector<std::string> get_shortest_path(std::string name,
        shortest_path_query query) {
     msgpack::rpc::future f = c_.call("get_shortest_path", name, query);
     return f.get<std::vector<std::string> >();
   }
-  
+
   bool update_index(std::string name) {
     msgpack::rpc::future f = c_.call("update_index", name);
     return f.get<bool>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   node get_node(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("get_node", name, node_id);
     return f.get<node>();
   }
-  
+
   edge get_edge(std::string name, std::string node_id, uint64_t edge_id) {
     msgpack::rpc::future f = c_.call("get_edge", name, node_id, edge_id);
     return f.get<edge>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
   }
-  
+
   bool create_node_here(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("create_node_here", name, node_id);
     return f.get<bool>();
   }
-  
+
   bool remove_global_node(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("remove_global_node", name, node_id);
     return f.get<bool>();
   }
-  
+
   bool create_edge_here(std::string name, uint64_t edge_id, edge e) {
     msgpack::rpc::future f = c_.call("create_edge_here", name, edge_id, e);
     return f.get<bool>();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/client/recommender_client.hpp
+++ b/client/recommender_client.hpp
@@ -21,83 +21,87 @@ class recommender {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   bool clear_row(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("clear_row", name, id);
     return f.get<bool>();
   }
-  
+
   bool update_row(std::string name, std::string id, datum row) {
     msgpack::rpc::future f = c_.call("update_row", name, id, row);
     return f.get<bool>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   datum complete_row_from_id(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("complete_row_from_id", name, id);
     return f.get<datum>();
   }
-  
+
   datum complete_row_from_datum(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("complete_row_from_datum", name, row);
     return f.get<datum>();
   }
-  
+
   similar_result similar_row_from_id(std::string name, std::string id,
        uint32_t size) {
     msgpack::rpc::future f = c_.call("similar_row_from_id", name, id, size);
     return f.get<similar_result>();
   }
-  
+
   similar_result similar_row_from_datum(std::string name, datum row,
        uint32_t size) {
     msgpack::rpc::future f = c_.call("similar_row_from_datum", name, row, size);
     return f.get<similar_result>();
   }
-  
+
   datum decode_row(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("decode_row", name, id);
     return f.get<datum>();
   }
-  
+
   std::vector<std::string> get_all_rows(std::string name) {
     msgpack::rpc::future f = c_.call("get_all_rows", name);
     return f.get<std::vector<std::string> >();
   }
-  
+
   float calc_similarity(std::string name, datum lhs, datum rhs) {
     msgpack::rpc::future f = c_.call("calc_similarity", name, lhs, rhs);
     return f.get<float>();
   }
-  
+
   float calc_l2norm(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("calc_l2norm", name, row);
     return f.get<float>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/client/regression_client.hpp
+++ b/client/regression_client.hpp
@@ -21,43 +21,47 @@ class regression {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   int32_t train(std::string name, std::vector<std::pair<float,
        datum> > train_data) {
     msgpack::rpc::future f = c_.call("train", name, train_data);
     return f.get<int32_t>();
   }
-  
+
   std::vector<float> estimate(std::string name,
        std::vector<datum> estimate_data) {
     msgpack::rpc::future f = c_.call("estimate", name, estimate_data);
     return f.get<std::vector<float> >();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/client/stat_client.hpp
+++ b/client/stat_client.hpp
@@ -21,67 +21,71 @@ class stat {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   bool push(std::string name, std::string key, double value) {
     msgpack::rpc::future f = c_.call("push", name, key, value);
     return f.get<bool>();
   }
-  
+
   double sum(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("sum", name, key);
     return f.get<double>();
   }
-  
+
   double stddev(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("stddev", name, key);
     return f.get<double>();
   }
-  
+
   double max(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("max", name, key);
     return f.get<double>();
   }
-  
+
   double min(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("min", name, key);
     return f.get<double>();
   }
-  
+
   double entropy(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("entropy", name, key);
     return f.get<double>();
   }
-  
+
   double moment(std::string name, std::string key, int32_t degree,
        double center) {
     msgpack::rpc::future f = c_.call("moment", name, key, degree, center);
     return f.get<double>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/anomaly_client.hpp
+++ b/src/server/anomaly_client.hpp
@@ -20,56 +20,60 @@ class anomaly {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   bool clear_row(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("clear_row", name, id);
     return f.get<bool>();
   }
-  
+
   std::pair<std::string, float> add(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("add", name, row);
     return f.get<std::pair<std::string, float> >();
   }
-  
+
   float update(std::string name, std::string id, datum row) {
     msgpack::rpc::future f = c_.call("update", name, id, row);
     return f.get<float>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   float calc_score(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("calc_score", name, row);
     return f.get<float>();
   }
-  
+
   std::vector<std::string> get_all_rows(std::string name) {
     msgpack::rpc::future f = c_.call("get_all_rows", name);
     return f.get<std::vector<std::string> >();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/anomaly_impl.cpp
+++ b/src/server/anomaly_impl.cpp
@@ -23,47 +23,47 @@ class anomaly_impl_ : public anomaly<anomaly_impl_> {
     JRLOCK__(p_);
     return get_p()->get_config();
   }
-  
+
   bool clear_row(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->clear_row(id);
   }
-  
+
   std::pair<std::string, float> add(std::string name, datum row) {
     JWLOCK__(p_);
     return get_p()->add(row);
   }
-  
+
   float update(std::string name, std::string id, datum row) {
     JWLOCK__(p_);
     return get_p()->update(id, row);
   }
-  
+
   bool clear(std::string name) {
     JWLOCK__(p_);
     return get_p()->clear();
   }
-  
+
   float calc_score(std::string name, datum row) {
     JRLOCK__(p_);
     return get_p()->calc_score(row);
   }
-  
+
   std::vector<std::string> get_all_rows(std::string name) {
     JRLOCK__(p_);
     return get_p()->get_all_rows();
   }
-  
+
   bool save(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->save(id);
   }
-  
+
   bool load(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->load(id);
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     JRLOCK__(p_);

--- a/src/server/anomaly_test.cpp
+++ b/src/server/anomaly_test.cpp
@@ -128,4 +128,12 @@ TEST_F(anomaly_test, small) {
   }
 }
 
+TEST_F(anomaly_test, api_get_client) {
+  jubatus::client::anomaly cli("localhost", PORT, 10);
+  string to_get = cli.get_config(NAME);
+
+  msgpack::rpc::client& conn = cli.get_client();
+  EXPECT_NO_THROW(conn.close());
+}
+
 }  // namespace

--- a/src/server/classifier_client.hpp
+++ b/src/server/classifier_client.hpp
@@ -20,43 +20,47 @@ class classifier {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   int32_t train(std::string name, std::vector<std::pair<std::string,
        datum> > data) {
     msgpack::rpc::future f = c_.call("train", name, data);
     return f.get<int32_t>();
   }
-  
+
   std::vector<std::vector<estimate_result> > classify(std::string name,
        std::vector<datum> data) {
     msgpack::rpc::future f = c_.call("classify", name, data);
     return f.get<std::vector<std::vector<estimate_result> > >();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/classifier_impl.cpp
+++ b/src/server/classifier_impl.cpp
@@ -23,34 +23,34 @@ class classifier_impl_ : public classifier<classifier_impl_> {
     JRLOCK__(p_);
     return get_p()->get_config();
   }
-  
+
   int32_t train(std::string name, std::vector<std::pair<std::string,
        datum> > data) {
     JWLOCK__(p_);
     return get_p()->train(data);
   }
-  
+
   std::vector<std::vector<estimate_result> > classify(std::string name,
        std::vector<datum> data) {
     JRLOCK__(p_);
     return get_p()->classify(data);
   }
-  
+
   bool clear(std::string name) {
     JWLOCK__(p_);
     return get_p()->clear();
   }
-  
+
   bool save(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->save(id);
   }
-  
+
   bool load(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->load(id);
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     JRLOCK__(p_);

--- a/src/server/classifier_test.cpp
+++ b/src/server/classifier_test.cpp
@@ -225,6 +225,14 @@ TEST_P(classifier_test, simple) {
   }
 }
 
+TEST_P(classifier_test, api_get_client) {
+  jubatus::client::classifier cli("localhost", PORT, 10);
+  string to_get = cli.get_config(NAME);
+
+  msgpack::rpc::client& conn = cli.get_client();
+  EXPECT_NO_THROW(conn.close());
+}
+
 TEST_P(classifier_test, api_config) {
   jubatus::client::classifier cli("localhost", PORT, 10);
   string to_get;

--- a/src/server/graph_client.hpp
+++ b/src/server/graph_client.hpp
@@ -20,126 +20,130 @@ class graph {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   std::string create_node(std::string name) {
     msgpack::rpc::future f = c_.call("create_node", name);
     return f.get<std::string>();
   }
-  
+
   bool remove_node(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("remove_node", name, node_id);
     return f.get<bool>();
   }
-  
+
   bool update_node(std::string name, std::string node_id, std::map<std::string,
        std::string> property) {
     msgpack::rpc::future f = c_.call("update_node", name, node_id, property);
     return f.get<bool>();
   }
-  
+
   uint64_t create_edge(std::string name, std::string node_id, edge e) {
     msgpack::rpc::future f = c_.call("create_edge", name, node_id, e);
     return f.get<uint64_t>();
   }
-  
+
   bool update_edge(std::string name, std::string node_id, uint64_t edge_id,
        edge e) {
     msgpack::rpc::future f = c_.call("update_edge", name, node_id, edge_id, e);
     return f.get<bool>();
   }
-  
+
   bool remove_edge(std::string name, std::string node_id, uint64_t edge_id) {
     msgpack::rpc::future f = c_.call("remove_edge", name, node_id, edge_id);
     return f.get<bool>();
   }
-  
+
   double get_centrality(std::string name, std::string node_id,
        int32_t centrality_type, preset_query query) {
     msgpack::rpc::future f = c_.call("get_centrality", name, node_id,
          centrality_type, query);
     return f.get<double>();
   }
-  
+
   bool add_centrality_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("add_centrality_query", name, query);
     return f.get<bool>();
   }
-  
+
   bool add_shortest_path_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("add_shortest_path_query", name, query);
     return f.get<bool>();
   }
-  
+
   bool remove_centrality_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("remove_centrality_query", name, query);
     return f.get<bool>();
   }
-  
+
   bool remove_shortest_path_query(std::string name, preset_query query) {
     msgpack::rpc::future f = c_.call("remove_shortest_path_query", name, query);
     return f.get<bool>();
   }
-  
+
   std::vector<std::string> get_shortest_path(std::string name,
        shortest_path_query query) {
     msgpack::rpc::future f = c_.call("get_shortest_path", name, query);
     return f.get<std::vector<std::string> >();
   }
-  
+
   bool update_index(std::string name) {
     msgpack::rpc::future f = c_.call("update_index", name);
     return f.get<bool>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   node get_node(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("get_node", name, node_id);
     return f.get<node>();
   }
-  
+
   edge get_edge(std::string name, std::string node_id, uint64_t edge_id) {
     msgpack::rpc::future f = c_.call("get_edge", name, node_id, edge_id);
     return f.get<edge>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
   }
-  
+
   bool create_node_here(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("create_node_here", name, node_id);
     return f.get<bool>();
   }
-  
+
   bool remove_global_node(std::string name, std::string node_id) {
     msgpack::rpc::future f = c_.call("remove_global_node", name, node_id);
     return f.get<bool>();
   }
-  
+
   bool create_edge_here(std::string name, uint64_t edge_id, edge e) {
     msgpack::rpc::future f = c_.call("create_edge_here", name, edge_id, e);
     return f.get<bool>();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/graph_impl.cpp
+++ b/src/server/graph_impl.cpp
@@ -23,117 +23,117 @@ class graph_impl_ : public graph<graph_impl_> {
     JRLOCK__(p_);
     return get_p()->get_config();
   }
-  
+
   std::string create_node(std::string name) {
     NOLOCK__(p_);
     return get_p()->create_node();
   }
-  
+
   bool remove_node(std::string name, std::string node_id) {
     JWLOCK__(p_);
     return get_p()->remove_node(node_id);
   }
-  
+
   bool update_node(std::string name, std::string node_id, std::map<std::string,
        std::string> property) {
     JWLOCK__(p_);
     return get_p()->update_node(node_id, property);
   }
-  
+
   uint64_t create_edge(std::string name, std::string node_id, edge e) {
     NOLOCK__(p_);
     return get_p()->create_edge(node_id, e);
   }
-  
+
   bool update_edge(std::string name, std::string node_id, uint64_t edge_id,
        edge e) {
     JWLOCK__(p_);
     return get_p()->update_edge(node_id, edge_id, e);
   }
-  
+
   bool remove_edge(std::string name, std::string node_id, uint64_t edge_id) {
     JWLOCK__(p_);
     return get_p()->remove_edge(node_id, edge_id);
   }
-  
+
   double get_centrality(std::string name, std::string node_id,
        int32_t centrality_type, preset_query query) {
     JRLOCK__(p_);
     return get_p()->get_centrality(node_id, centrality_type, query);
   }
-  
+
   bool add_centrality_query(std::string name, preset_query query) {
     JWLOCK__(p_);
     return get_p()->add_centrality_query(query);
   }
-  
+
   bool add_shortest_path_query(std::string name, preset_query query) {
     JWLOCK__(p_);
     return get_p()->add_shortest_path_query(query);
   }
-  
+
   bool remove_centrality_query(std::string name, preset_query query) {
     JWLOCK__(p_);
     return get_p()->remove_centrality_query(query);
   }
-  
+
   bool remove_shortest_path_query(std::string name, preset_query query) {
     JWLOCK__(p_);
     return get_p()->remove_shortest_path_query(query);
   }
-  
+
   std::vector<std::string> get_shortest_path(std::string name,
        shortest_path_query query) {
     JRLOCK__(p_);
     return get_p()->get_shortest_path(query);
   }
-  
+
   bool update_index(std::string name) {
     JWLOCK__(p_);
     return get_p()->update_index();
   }
-  
+
   bool clear(std::string name) {
     JWLOCK__(p_);
     return get_p()->clear();
   }
-  
+
   node get_node(std::string name, std::string node_id) {
     JRLOCK__(p_);
     return get_p()->get_node(node_id);
   }
-  
+
   edge get_edge(std::string name, std::string node_id, uint64_t edge_id) {
     JRLOCK__(p_);
     return get_p()->get_edge(node_id, edge_id);
   }
-  
+
   bool save(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->save(id);
   }
-  
+
   bool load(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->load(id);
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     JRLOCK__(p_);
     return p_->get_status();
   }
-  
+
   bool create_node_here(std::string name, std::string node_id) {
     JWLOCK__(p_);
     return get_p()->create_node_here(node_id);
   }
-  
+
   bool remove_global_node(std::string name, std::string node_id) {
     JWLOCK__(p_);
     return get_p()->remove_global_node(node_id);
   }
-  
+
   bool create_edge_here(std::string name, uint64_t edge_id, edge e) {
     JWLOCK__(p_);
     return get_p()->create_edge_here(edge_id, e);

--- a/src/server/graph_test.cpp
+++ b/src/server/graph_test.cpp
@@ -151,4 +151,12 @@ TEST_F(graph_test, simple) {
   }
 }
 
+TEST_F(graph_test, api_get_client) {
+  jubatus::client::graph cli("localhost", PORT, 10);
+  string to_get = cli.get_config("");
+
+  msgpack::rpc::client& conn = cli.get_client();
+  EXPECT_NO_THROW(conn.close());
+}
+
 }  // namespace

--- a/src/server/recommender_client.hpp
+++ b/src/server/recommender_client.hpp
@@ -20,83 +20,87 @@ class recommender {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   bool clear_row(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("clear_row", name, id);
     return f.get<bool>();
   }
-  
+
   bool update_row(std::string name, std::string id, datum row) {
     msgpack::rpc::future f = c_.call("update_row", name, id, row);
     return f.get<bool>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   datum complete_row_from_id(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("complete_row_from_id", name, id);
     return f.get<datum>();
   }
-  
+
   datum complete_row_from_datum(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("complete_row_from_datum", name, row);
     return f.get<datum>();
   }
-  
+
   similar_result similar_row_from_id(std::string name, std::string id,
        uint32_t size) {
     msgpack::rpc::future f = c_.call("similar_row_from_id", name, id, size);
     return f.get<similar_result>();
   }
-  
+
   similar_result similar_row_from_datum(std::string name, datum row,
        uint32_t size) {
     msgpack::rpc::future f = c_.call("similar_row_from_datum", name, row, size);
     return f.get<similar_result>();
   }
-  
+
   datum decode_row(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("decode_row", name, id);
     return f.get<datum>();
   }
-  
+
   std::vector<std::string> get_all_rows(std::string name) {
     msgpack::rpc::future f = c_.call("get_all_rows", name);
     return f.get<std::vector<std::string> >();
   }
-  
+
   float calc_similarity(std::string name, datum lhs, datum rhs) {
     msgpack::rpc::future f = c_.call("calc_similarity", name, lhs, rhs);
     return f.get<float>();
   }
-  
+
   float calc_l2norm(std::string name, datum row) {
     msgpack::rpc::future f = c_.call("calc_l2norm", name, row);
     return f.get<float>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/recommender_impl.cpp
+++ b/src/server/recommender_impl.cpp
@@ -23,74 +23,74 @@ class recommender_impl_ : public recommender<recommender_impl_> {
     JRLOCK__(p_);
     return get_p()->get_config();
   }
-  
+
   bool clear_row(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->clear_row(id);
   }
-  
+
   bool update_row(std::string name, std::string id, datum row) {
     JWLOCK__(p_);
     return get_p()->update_row(id, row);
   }
-  
+
   bool clear(std::string name) {
     JWLOCK__(p_);
     return get_p()->clear();
   }
-  
+
   datum complete_row_from_id(std::string name, std::string id) {
     JRLOCK__(p_);
     return get_p()->complete_row_from_id(id);
   }
-  
+
   datum complete_row_from_datum(std::string name, datum row) {
     JRLOCK__(p_);
     return get_p()->complete_row_from_datum(row);
   }
-  
+
   similar_result similar_row_from_id(std::string name, std::string id,
        uint32_t size) {
     JRLOCK__(p_);
     return get_p()->similar_row_from_id(id, size);
   }
-  
+
   similar_result similar_row_from_datum(std::string name, datum row,
        uint32_t size) {
     JRLOCK__(p_);
     return get_p()->similar_row_from_datum(row, size);
   }
-  
+
   datum decode_row(std::string name, std::string id) {
     JRLOCK__(p_);
     return get_p()->decode_row(id);
   }
-  
+
   std::vector<std::string> get_all_rows(std::string name) {
     JRLOCK__(p_);
     return get_p()->get_all_rows();
   }
-  
+
   float calc_similarity(std::string name, datum lhs, datum rhs) {
     JRLOCK__(p_);
     return get_p()->calc_similarity(lhs, rhs);
   }
-  
+
   float calc_l2norm(std::string name, datum row) {
     JRLOCK__(p_);
     return get_p()->calc_l2norm(row);
   }
-  
+
   bool save(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->save(id);
   }
-  
+
   bool load(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->load(id);
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     JRLOCK__(p_);

--- a/src/server/recommender_test.cpp
+++ b/src/server/recommender_test.cpp
@@ -130,6 +130,14 @@ TEST_F(recommender_test, small) {
   c.load(NAME, "name");
 }
 
+TEST_F(recommender_test, api_get_client) {
+  jubatus::client::recommender cli("localhost", PORT, 10);
+  string to_get = cli.get_config(NAME);
+
+  msgpack::rpc::client& conn = cli.get_client();
+  EXPECT_NO_THROW(conn.close());
+}
+
 sfv_diff_t make_vec(float v1, float v2, float v3) {
   sfv_diff_t v;
   v.push_back(make_pair("c1", v1));

--- a/src/server/regression_client.hpp
+++ b/src/server/regression_client.hpp
@@ -20,43 +20,47 @@ class regression {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   int32_t train(std::string name, std::vector<std::pair<float,
        datum> > train_data) {
     msgpack::rpc::future f = c_.call("train", name, train_data);
     return f.get<int32_t>();
   }
-  
+
   std::vector<float> estimate(std::string name,
        std::vector<datum> estimate_data) {
     msgpack::rpc::future f = c_.call("estimate", name, estimate_data);
     return f.get<std::vector<float> >();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/regression_impl.cpp
+++ b/src/server/regression_impl.cpp
@@ -23,34 +23,34 @@ class regression_impl_ : public regression<regression_impl_> {
     JRLOCK__(p_);
     return get_p()->get_config();
   }
-  
+
   int32_t train(std::string name, std::vector<std::pair<float,
        datum> > train_data) {
     JWLOCK__(p_);
     return get_p()->train(train_data);
   }
-  
+
   std::vector<float> estimate(std::string name,
        std::vector<datum> estimate_data) {
     JRLOCK__(p_);
     return get_p()->estimate(estimate_data);
   }
-  
+
   bool clear(std::string name) {
     JWLOCK__(p_);
     return get_p()->clear();
   }
-  
+
   bool save(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->save(id);
   }
-  
+
   bool load(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->load(id);
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     JRLOCK__(p_);

--- a/src/server/regression_test.cpp
+++ b/src/server/regression_test.cpp
@@ -184,4 +184,12 @@ TEST_F(regression_test, small) {
   cout << res.size() << endl;
 }
 
+TEST_F(regression_test, api_get_client) {
+  jubatus::client::regression cli("localhost", PORT, 10);
+  string to_get = cli.get_config(NAME);
+
+  msgpack::rpc::client& conn = cli.get_client();
+  EXPECT_NO_THROW(conn.close());
+}
+
 }  // namespace

--- a/src/server/stat_client.hpp
+++ b/src/server/stat_client.hpp
@@ -20,67 +20,71 @@ class stat {
       : c_(host, port) {
     c_.set_timeout(timeout_sec);
   }
-  
+
   std::string get_config(std::string name) {
     msgpack::rpc::future f = c_.call("get_config", name);
     return f.get<std::string>();
   }
-  
+
   bool push(std::string name, std::string key, double value) {
     msgpack::rpc::future f = c_.call("push", name, key, value);
     return f.get<bool>();
   }
-  
+
   double sum(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("sum", name, key);
     return f.get<double>();
   }
-  
+
   double stddev(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("stddev", name, key);
     return f.get<double>();
   }
-  
+
   double max(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("max", name, key);
     return f.get<double>();
   }
-  
+
   double min(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("min", name, key);
     return f.get<double>();
   }
-  
+
   double entropy(std::string name, std::string key) {
     msgpack::rpc::future f = c_.call("entropy", name, key);
     return f.get<double>();
   }
-  
+
   double moment(std::string name, std::string key, int32_t degree,
        double center) {
     msgpack::rpc::future f = c_.call("moment", name, key, degree, center);
     return f.get<double>();
   }
-  
+
   bool clear(std::string name) {
     msgpack::rpc::future f = c_.call("clear", name);
     return f.get<bool>();
   }
-  
+
   bool save(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("save", name, id);
     return f.get<bool>();
   }
-  
+
   bool load(std::string name, std::string id) {
     msgpack::rpc::future f = c_.call("load", name, id);
     return f.get<bool>();
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     msgpack::rpc::future f = c_.call("get_status", name);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
+  }
+
+  msgpack::rpc::client& get_client() {
+    return c_;
   }
 
  private:

--- a/src/server/stat_impl.cpp
+++ b/src/server/stat_impl.cpp
@@ -23,58 +23,58 @@ class stat_impl_ : public stat<stat_impl_> {
     JRLOCK__(p_);
     return get_p()->get_config();
   }
-  
+
   bool push(std::string name, std::string key, double value) {
     JWLOCK__(p_);
     return get_p()->push(key, value);
   }
-  
+
   double sum(std::string name, std::string key) {
     JRLOCK__(p_);
     return get_p()->sum(key);
   }
-  
+
   double stddev(std::string name, std::string key) {
     JRLOCK__(p_);
     return get_p()->stddev(key);
   }
-  
+
   double max(std::string name, std::string key) {
     JRLOCK__(p_);
     return get_p()->max(key);
   }
-  
+
   double min(std::string name, std::string key) {
     JRLOCK__(p_);
     return get_p()->min(key);
   }
-  
+
   double entropy(std::string name, std::string key) {
     JRLOCK__(p_);
     return get_p()->entropy(key);
   }
-  
+
   double moment(std::string name, std::string key, int32_t degree,
        double center) {
     JRLOCK__(p_);
     return get_p()->moment(key, degree, center);
   }
-  
+
   bool clear(std::string name) {
     JWLOCK__(p_);
     return get_p()->clear();
   }
-  
+
   bool save(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->save(id);
   }
-  
+
   bool load(std::string name, std::string id) {
     JWLOCK__(p_);
     return get_p()->load(id);
   }
-  
+
   std::map<std::string, std::map<std::string, std::string> > get_status(
       std::string name) {
     JRLOCK__(p_);

--- a/src/server/stat_test.cpp
+++ b/src/server/stat_test.cpp
@@ -58,4 +58,12 @@ TEST_F(stat_test, small) {
   ASSERT_EQ(true, c.load("", __func__));
 }
 
+TEST_F(stat_test, api_get_client) {
+  jubatus::client::stat cli("localhost", PORT, 10);
+  cli.clear("");
+
+  msgpack::rpc::client& conn = cli.get_client();
+  EXPECT_NO_THROW(conn.close());
+}
+
 }  // namespace

--- a/tools/jenerator/src/cpp.ml
+++ b/tools/jenerator/src/cpp.ml
@@ -36,7 +36,9 @@ let parse_namespace namespace =
 ;;
 
 let indent_line n (ind, line) =
-  (ind + n, line)
+  match line with
+  | "" -> (ind, line)
+  | _ -> (ind + n, line)
 ;;
 
 let indent_lines n =


### PR DESCRIPTION
add get_client() method to jenerator's cpp-client output ( related to #244, #291 ).
get_client()'s signature is:

<pre>
msgpack::rpc::client& get_client()
</pre>


We can close a session explicitly like this `cli.get_client().close()`
