### PR TITLE
Dead lock in anomaly::add method.

### DIFF
--- a/src/server/anomaly.idl
+++ b/src/server/anomaly.idl
@@ -50,7 +50,7 @@ service anomaly {
   bool clear_row(0: string name, 1: string id) # //@cht
 
   #- add a point.
-  #@random #@update #@pass
+  #@random #@nolock #@pass
   tuple<string, float> add(0: string name, 1: datum row) # //@random
 
   #- update a point.

--- a/src/server/anomaly_impl.cpp
+++ b/src/server/anomaly_impl.cpp
@@ -30,7 +30,7 @@ class anomaly_impl_ : public anomaly<anomaly_impl_> {
   }
 
   std::pair<std::string, float> add(std::string name, datum row) {
-    JWLOCK__(p_);
+    NOLOCK__(p_);
     return get_p()->add(row);
   }
 

--- a/src/server/anomaly_serv.cpp
+++ b/src/server/anomaly_serv.cpp
@@ -159,6 +159,8 @@ pair<string, float> anomaly_serv::add(const datum& d) {
 #ifdef HAVE_ZOOKEEPER_H
   if (argv().is_standalone()) {
 #endif
+    pfi::concurrent::scoped_lock lk(wlock(rw_mutex()));
+    event_model_updated();
     fv_converter::datum data;
     convert(d, data);
     return anomaly_->add(id_str, data);
@@ -253,6 +255,7 @@ float anomaly_serv::selective_update(
   // nolock context
   if (host == argv().eth && port == argv().port) {
     pfi::concurrent::scoped_lock lk(wlock(rw_mutex()));
+    event_model_updated();
     return this->update(id, d);
   } else {  // needs no lock
     client::anomaly c(host, port, 5.0);


### PR DESCRIPTION
When I executed "add" function of anomaly in parallel with ZooKeeper, 
the following log message was printed.

```
W0415 16:46:56.774195 27919 anomaly_serv.cpp:159] cannot create 1th replica: 192.168.10.10:9208
W0415 16:46:56.774281 27919 anomaly_serv.cpp:161] request timed out
```

I searched the cause of this log message, and found the dead-lock in "add" function of jubaanomaly.

"add" function is defined as "#@update" function in IDL.
Thus "add" function acquires write-lock.
but "add" function calls "update_row" function in other servers.
"update_row" is the "#@update" function, thus it acquires write-lock.

That is, "add" function tries to acquire write-lock of another server, while it holds write-lock.
While 2 servers have held their own lock, when they try to acquire a partner's lock mutually, deadlock occurs. 
