### PR TITLE
Generate random vectors in make_random. fixes #398

### DIFF
--- a/jubatus/core/classifier/classifier_test.cpp
+++ b/jubatus/core/classifier/classifier_test.cpp
@@ -92,18 +92,19 @@ common::sfv_t convert(vector<double>& v) {
 }
 
 TYPED_TEST_P(classifier_test, random) {
+  pfi::math::random::mtrand rand(0);
   local_storage s;
   TypeParam p(&s);
 
   srand(0);
   for (size_t i = 0; i < 1000; ++i) {
-    pair<string, vector<double> > d = gen_random_data();
+    pair<string, vector<double> > d = gen_random_data(rand);
     p.train(convert(d.second), d.first);
   }
 
   size_t correct = 0;
   for (size_t i = 0; i < 100; ++i) {
-    pair<string, vector<double> > d = gen_random_data();
+    pair<string, vector<double> > d = gen_random_data(rand);
     if (d.first == p.classify(convert(d.second))) {
       ++correct;
     }
@@ -112,18 +113,19 @@ TYPED_TEST_P(classifier_test, random) {
 }
 
 TYPED_TEST_P(classifier_test, random3) {
+  pfi::math::random::mtrand rand(0);
   local_storage s;
   TypeParam p(&s);
 
   srand(0);
   for (size_t i = 0; i < 1000; ++i) {
-    pair<string, vector<double> > d = gen_random_data3();
+    pair<string, vector<double> > d = gen_random_data3(rand);
     p.train(convert(d.second), d.first);
   }
 
   size_t correct = 0;
   for (size_t i = 0; i < 100; ++i) {
-    pair<string, vector<double> > d = gen_random_data3();
+    pair<string, vector<double> > d = gen_random_data3(rand);
     if (d.first == p.classify(convert(d.second))) {
       ++correct;
     }

--- a/jubatus/core/classifier/classifier_test_util.hpp
+++ b/jubatus/core/classifier/classifier_test_util.hpp
@@ -27,8 +27,12 @@
 
 #include <pficommon/math/random.h>
 
-void make_random(float mu, float sigma, size_t dim, std::vector<double>& v) {
-  pfi::math::random::mtrand rand(0);
+void make_random(
+    pfi::math::random::mtrand& rand,
+    float mu,
+    float sigma,
+    size_t dim,
+    std::vector<double>& v) {
   for (size_t i = 0; i < dim; i++) {
     float value = rand.next_gaussian(mu, sigma);
     v.push_back(value);
@@ -36,21 +40,22 @@ void make_random(float mu, float sigma, size_t dim, std::vector<double>& v) {
 }
 
 void make_random(
+    pfi::math::random::mtrand& rand,
     const std::vector<float>& mus,
     float sigma,
     size_t dim,
     std::vector<double>& v) {
-  pfi::math::random::mtrand rand(0);
   for (size_t i = 0; i < dim; i++) {
     float value = rand.next_gaussian(mus[i % mus.size()], sigma);
     v.push_back(value);
   }
 }
 
-std::pair<std::string, std::vector<double> > gen_random_data() {
+std::pair<std::string, std::vector<double> > gen_random_data(
+    pfi::math::random::mtrand& rand) {
   const float mu_pos = 1.0;
   const float mu_neg = -1.0;
-  const float sigma = 1.0;
+  const float sigma = 1.5;
   const size_t dim = 10;
 
   float mu;
@@ -62,11 +67,12 @@ std::pair<std::string, std::vector<double> > gen_random_data() {
     p.first = "NG";
     mu = mu_neg;
   }
-  make_random(mu, sigma, dim, p.second);
+  make_random(rand, mu, sigma, dim, p.second);
   return p;
 }
 
-std::pair<std::string, std::vector<double> > gen_random_data3() {
+std::pair<std::string, std::vector<double> > gen_random_data3(
+    pfi::math::random::mtrand& rand) {
   const char* labels[] = { "1", "2", "3" };
   std::vector<float> mus;
   mus.push_back(3);
@@ -80,7 +86,7 @@ std::pair<std::string, std::vector<double> > gen_random_data3() {
   size_t l = rand() % 3;
   p.first = labels[l];
   std::rotate(mus.begin(), mus.begin() + l, mus.end());
-  make_random(mus, sigma, dim, p.second);
+  make_random(rand, mus, sigma, dim, p.second);
   return p;
 }
 

--- a/jubatus/core/driver/classifier_test.cpp
+++ b/jubatus/core/driver/classifier_test.cpp
@@ -63,9 +63,12 @@ datum convert_vector(const vector<double>& vec) {
   return d;
 }
 
-void make_random_data(vector<pair<string, datum> >& data, size_t size) {
+void make_random_data(
+    pfi::math::random::mtrand& rand,
+    vector<pair<string, datum> >& data,
+    size_t size) {
   for (size_t i = 0; i < size; ++i) {
-    pair<string, vector<double> > p = gen_random_data();
+    pair<string, vector<double> > p = gen_random_data(rand);
     data.push_back(make_pair(p.first, convert_vector(p.second)));
   }
 }
@@ -111,20 +114,22 @@ TEST_P(classifier_test, simple) {
 }
 
 TEST_P(classifier_test, api_train) {
+  pfi::math::random::mtrand rand(0);
   const size_t example_size = 1000;
 
   vector<pair<string, datum> > data;
-  make_random_data(data, example_size);
+  make_random_data(rand, data, example_size);
   for (size_t i = 0; i < example_size; i++) {
     classifier_->train(data[i]);
   }
 }
 
 void classifier_test::my_test() {
+  pfi::math::random::mtrand rand(0);
   const size_t example_size = 1000;
 
   vector<pair<string, datum> > data;
-  make_random_data(data, example_size);
+  make_random_data(rand, data, example_size);
   for (size_t i = 0; i < example_size; i++) {
     classifier_->train(data[i]);
   }
@@ -169,8 +174,8 @@ void classifier_test::my_test() {
       }
     }
   }
-  // num of wrong classification should be less than 1%
-  EXPECT_GE(count, result.size() - 10);
+  // num of wrong classification should be less than 5%
+  EXPECT_GE(count, result.size() - 50);
 }
 
 TEST_P(classifier_test, my_test) {
@@ -206,10 +211,11 @@ TEST_P(classifier_test, duplicated_keys) {
 }
 
 TEST_P(classifier_test, save_load) {
+  pfi::math::random::mtrand rand(0);
   const size_t example_size = 1000;
 
   vector<pair<string, datum> > data;
-  make_random_data(data, example_size);
+  make_random_data(rand, data, example_size);
   for (size_t i = 0; i < example_size; i++) {
     classifier_->train(data[i]);
   }

--- a/jubatus/core/recommender/recommender_random_test.cpp
+++ b/jubatus/core/recommender/recommender_random_test.cpp
@@ -73,6 +73,7 @@ TYPED_TEST_P(recommender_random_test, trivial) {
 }
 
 TYPED_TEST_P(recommender_random_test, random) {
+  pfi::math::random::mtrand rand(0);
   TypeParam r;
 
   // Generate random data from two norma distributions, N1 and N2.
@@ -82,7 +83,7 @@ TYPED_TEST_P(recommender_random_test, random) {
   mu1.push_back(1.0);
   for (size_t i = 0; i < 100; ++i) {
     vector<double> v;
-    make_random(mu1, 1.0, 3, v);
+    make_random(rand, mu1, 1.0, 3, v);
     string row_name = "r1_" + lexical_cast<string>(i);
     r.update_row(row_name, make_vec(v[0], v[1], v[2]));
   }
@@ -93,7 +94,7 @@ TYPED_TEST_P(recommender_random_test, random) {
   mu2.push_back(-1.0);
   for (size_t i = 0; i < 100; ++i) {
     vector<double> v;
-    make_random(mu2, 1.0, 3, v);
+    make_random(rand, mu2, 1.0, 3, v);
     string row_name = "r2_" + lexical_cast<string>(i);
     r.update_row(row_name, make_vec(v[0], v[1], v[2]));
   }
@@ -128,10 +129,11 @@ TYPED_TEST_P(recommender_random_test, random) {
 }
 
 void update_random(recommender_base& r) {
+  pfi::math::random::mtrand rand(0);
   vector<float> mu(3);
   for (size_t i = 0; i < 100; ++i) {
     vector<double> v;
-    make_random(mu, 1.0, 3, v);
+    make_random(rand, mu, 1.0, 3, v);
     string row_name = "r1_" + lexical_cast<string>(i);
     r.update_row(row_name, make_vec(v[0], v[1], v[2]));
   }
@@ -234,11 +236,12 @@ TYPED_TEST_P(recommender_random_test, diff) {
 }
 
 TYPED_TEST_P(recommender_random_test, mix) {
+  pfi::math::random::mtrand rand(0);
   TypeParam r1, r2, expect;
   vector<float> mu(10);
   for (size_t i = 0; i < 100; ++i) {
     vector<double> v;
-    make_random(mu, 1.0, 3, v);
+    make_random(rand, mu, 1.0, 3, v);
     common::sfv_t vec = make_vec(v[0], v[1], v[2]);
 
     string row = "r_" + lexical_cast<string>(i);


### PR DESCRIPTION
Original `make_random` generates same vectors in a test set. So, in all the test cases all classifiers achieved 100% accuracy. I fixed it to make different vectors in a data set by using the same random generator without initializing it.
