### PR TITLE
Feature/config cast typo error: fix #488

### DIFF
--- a/jubatus/core/common/jsonconfig/exception.cpp
+++ b/jubatus/core/common/jsonconfig/exception.cpp
@@ -75,6 +75,10 @@ std::string MakeNotFoundMessage(const std::string& key) {
   return "\"" + key + "\" is not found";
 }
 
+std::string MakeRedundantKeyMessage(const std::string& key) {
+  return "\"" + key + "\" is not used";
+}
+
 }  // namespace
 
 type_error::type_error(
@@ -104,6 +108,14 @@ not_found::not_found(const std::string& path, const std::string& key)
 }
 
 not_found::~not_found() throw () {
+}
+
+redundant_key::redundant_key(const std::string& path, const std::string& key)
+    : config_error(path, MakeRedundantKeyMessage(key)),
+      key_(key) {
+}
+
+redundant_key::~redundant_key() throw () {
 }
 
 cast_check_error::cast_check_error(

--- a/jubatus/core/common/jsonconfig/exception.hpp
+++ b/jubatus/core/common/jsonconfig/exception.hpp
@@ -106,6 +106,20 @@ class not_found : public config_error {
   std::string key_;
 };
 
+class redundant_key : public config_error {
+ public:
+  redundant_key(const std::string& path, const std::string& key);
+
+  ~redundant_key() throw();
+
+  const std::string& key() const {
+    return key_;
+  }
+
+ private:
+  std::string key_;
+};
+
 // cast_check_error DOES NOT INHERIT Config_error
 class cast_check_error
   : public common::exception::jubaexception<cast_check_error> {

--- a/jubatus/core/common/jsonconfig_test.cpp
+++ b/jubatus/core/common/jsonconfig_test.cpp
@@ -483,6 +483,22 @@ TEST(jsonconfig_cast, cast_check_error) {
   }
 }
 
+TEST(josnconfig_cast, cast_check_warning) {
+  config conf(lexical_cast<json>(
+      "{\"web_server\": { \"host\" : \"localhost\", \"port\": 80, \"test\": 1},"
+      "\"users\": [\"abc\"]}"));
+  try {
+    config_cast_check<server_conf>(conf);
+    FAIL();
+  } catch (const cast_check_error& e) {
+    const config_error_list& errors = e.errors();
+    ASSERT_EQ(1u, errors.size());
+
+    redundant_key* e1 = dynamic_cast<redundant_key*>(errors[0].get());
+    EXPECT_EQ(".web_server", e1->path());
+  }
+}
+
 }  // namespace jsonconfig
 }  // namespace common
 }  // namespace core


### PR DESCRIPTION
When redundant keys are found in the configuration, Jubatus report it as an error.
