### PR TITLE
hotfix: [or] operator is deprecated in ocaml4

### DIFF
--- a/tools/jenerator/src/cpp.ml
+++ b/tools/jenerator/src/cpp.ml
@@ -55,7 +55,7 @@ let rec gen_template names typ args =
 and gen_template_with_strs typ arg_strs =
   let s = String.concat ", " arg_strs in
   let len = String.length s in
-  if len = 0 or s.[len - 1] = '>' then
+  if len = 0 || s.[len - 1] = '>' then
     typ ^ "<" ^ s ^ " >"
   else
     typ ^ "<" ^ s ^ ">"
@@ -660,8 +660,8 @@ let gen_server_template_header_method names m =
 let filter_methods methods =
   List.filter (fun m ->
     not (m.method_name = "save"
-         or m.method_name = "load"
-         or m.method_name = "get_status")
+         || m.method_name = "load"
+         || m.method_name = "get_status")
   ) methods
 ;;
 

--- a/tools/jenerator/src/file_util.ml
+++ b/tools/jenerator/src/file_util.ml
@@ -48,7 +48,7 @@ let file_exist path =
 ;;
 
 let rec split_path path =
-  if path = "." or path ="/" then
+  if path = "." || path ="/" then
     [path]
   else
     let dir = Filename.dirname path in


### PR DESCRIPTION
In jenkins environment, OCaml compiler's version is 4.01(latest stable).

In OCaml version 4 compiler, the `or` operator is deprecated, then annotated to use `||` operator instead.
