### PR TITLE
Fix typedef and include guard in clustering and cluster_analysis

### DIFF
--- a/jubatus/core/cluster_analysis/cluster_analysis.cpp
+++ b/jubatus/core/cluster_analysis/cluster_analysis.cpp
@@ -52,31 +52,31 @@ bool is_same_datum(
 }
 
 double accumulate_weight(
-    const std::vector<std::pair<double, fv_converter::datum> >& set) {
+    const cluster_unit& cluster) {
   double sum = 0;
-  for (size_t i = 0; i < set.size(); ++i) {
-    sum += set[i].first;
+  for (size_t i = 0; i < cluster.size(); ++i) {
+    sum += cluster[i].first;
   }
   return sum;
 }
 
 double compute_jaccard_coefficient(
-    const std::vector<std::pair<double, fv_converter::datum> >& set1,
-    const std::vector<std::pair<double, fv_converter::datum> >& set2) {
-  if (set1.empty() || set2.empty()) {
+    const cluster_unit& cluster1,
+    const cluster_unit& cluster2) {
+  if (cluster1.empty() || cluster2.empty()) {
     return 0;
   }
   double intersec = 0;
-  for (size_t i = 0; i < set1.size(); ++i) {
-    for (size_t j = 0; j < set2.size(); ++j) {
-      if (is_same_datum(set1[i].second, set2[j].second)) {
-        intersec += std::min(set1[i].first, set2[j].first);
+  for (size_t i = 0; i < cluster1.size(); ++i) {
+    for (size_t j = 0; j < cluster2.size(); ++j) {
+      if (is_same_datum(cluster1[i].second, cluster2[j].second)) {
+        intersec += std::min(cluster1[i].first, cluster2[j].first);
         break;
       }
     }
   }
   const double union_weight =
-      accumulate_weight(set1) + accumulate_weight(set2) - intersec;
+      accumulate_weight(cluster1) + accumulate_weight(cluster2) - intersec;
   return intersec / union_weight;
 }
 
@@ -110,9 +110,8 @@ void convert(clustering::datum& src, fv_converter::datum& dst) {
   src.num_values.swap(dst.num_values_);
 }
 
-void convert(
-    std::vector<std::vector<std::pair<double, clustering::datum> > >& src,
-    std::vector<std::vector<std::pair<double, fv_converter::datum> > >& dst) {
+void convert(std::vector<std::vector<std::pair<cluster_weight,
+                 clustering::datum> > >& src, cluster_set& dst) {
   dst.resize(src.size());
   for (size_t i = 0; i < src.size(); ++i) {
     dst[i].resize(src[i].size());
@@ -137,10 +136,9 @@ void cluster_analysis::add_snapshot(const string& clustering_name) {
   clustering_snapshot snapshot;
   snapshot.name = clustering_name;
 
-  std::vector<std::vector<std::pair<double, clustering::datum> > > ret =
-      client_.get_core_members(config_.name);
+  std::vector<std::vector<std::pair<cluster_weight,
+        clustering::datum> > > ret = client_.get_core_members(config_.name);
 
-  convert(ret, snapshot.clusters);
   if (snapshots_.size() == static_cast<size_t>(config_.num_snapshots)) {
     snapshots_.pop_front();
   }

--- a/jubatus/core/cluster_analysis/cluster_analysis_config.hpp
+++ b/jubatus/core/cluster_analysis/cluster_analysis_config.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTER_ANALYSIS_CLUSTER_ANALYSIS_CONFIG_HPP_
-#define JUBATUS_CLUSTER_ANALYSIS_CLUSTER_ANALYSIS_CONFIG_HPP_
+#ifndef JUBATUS_CORE_CLUSTER_ANALYSIS_CLUSTER_ANALYSIS_CONFIG_HPP_
+#define JUBATUS_CORE_CLUSTER_ANALYSIS_CLUSTER_ANALYSIS_CONFIG_HPP_
 
 #include <string>
 #include <pficommon/data/serialization.h>
@@ -31,9 +31,10 @@ struct cluster_analysis_config {
   double timeout_sec;
   int num_snapshots;
 
-  template<typename Ar>
+  template <typename Ar>
   void serialize(Ar& ar) {
-    ar & MEMBER(name)
+    ar
+        & MEMBER(name)
         & MEMBER(host)
         & MEMBER(port)
         & MEMBER(timeout_sec)

--- a/jubatus/core/cluster_analysis/cluster_analysis_types.hpp
+++ b/jubatus/core/cluster_analysis/cluster_analysis_types.hpp
@@ -33,6 +33,11 @@ namespace jubatus {
 namespace core {
 namespace cluster_analysis {
 
+typedef double cluster_weight;
+typedef std::vector<std::pair<cluster_weight,
+            jubatus::core::fv_converter::datum> > cluster_unit;
+typedef std::vector<cluster_unit> cluster_set;
+
 struct cluster_relation {
   MSGPACK_DEFINE(cluster1, cluster2, similarity);
   int32_t cluster1;
@@ -50,8 +55,7 @@ struct change_graph {
 struct clustering_snapshot {
   MSGPACK_DEFINE(name, clusters);
   std::string name;
-  std::vector<std::vector<std::pair<double,
-       jubatus::core::fv_converter::datum> > > clusters;
+  cluster_set clusters;
 };
 
 }  // namespace cluster_analysis

--- a/jubatus/core/clustering/clustering.hpp
+++ b/jubatus/core/clustering/clustering.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTERING_HPP_
-#define JUBATUS_CLUSTERING_CLUSTERING_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_CLUSTERING_HPP_
+#define JUBATUS_CORE_CLUSTERING_CLUSTERING_HPP_
 
 #include <stdint.h>
 #include <cstdlib>

--- a/jubatus/core/clustering/clustering_config.hpp
+++ b/jubatus/core/clustering/clustering_config.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTERING_CONFIG_HPP_
-#define JUBATUS_CLUSTERING_CLUSTERING_CONFIG_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_CLUSTERING_CONFIG_HPP_
+#define JUBATUS_CORE_CLUSTERING_CLUSTERING_CONFIG_HPP_
 
 #include <string>
 #include <msgpack.hpp>

--- a/jubatus/core/clustering/clustering_method.hpp
+++ b/jubatus/core/clustering/clustering_method.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTER_MANAGER_HPP_
-#define JUBATUS_CLUSTERING_CLUSTER_MANAGER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_CLUSTERING_METHOD_HPP_
+#define JUBATUS_CORE_CLUSTERING_CLUSTERING_METHOD_HPP_
 
 #include <vector>
 #include <pficommon/data/serialization.h>

--- a/jubatus/core/clustering/clustering_method_factory.hpp
+++ b/jubatus/core/clustering/clustering_method_factory.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTER_MANAGER_FACTORY_HPP_
-#define JUBATUS_CLUSTERING_CLUSTER_MANAGER_FACTORY_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_CLUSTERING_METHOD_FACTORY_HPP_
+#define JUBATUS_CORE_CLUSTERING_CLUSTERING_METHOD_FACTORY_HPP_
 
 #include <string>
 #include <pficommon/lang/shared_ptr.h>

--- a/jubatus/core/clustering/clustering_method_serializer.hpp
+++ b/jubatus/core/clustering/clustering_method_serializer.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTERING_METHOD_SERIALIZER_HPP_
-#define JUBATUS_CLUSTERING_CLUSTERING_METHOD_SERIALIZER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_CLUSTERING_METHOD_SERIALIZER_HPP_
+#define JUBATUS_CORE_CLUSTERING_CLUSTERING_METHOD_SERIALIZER_HPP_
 
 #include <string>
 #include "clustering_method.hpp"

--- a/jubatus/core/clustering/compressive_storage.hpp
+++ b/jubatus/core/clustering/compressive_storage.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_COMPRESSIVE_STORAGE_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_COMPRESSIVE_STORAGE_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_COMPRESSIVE_STORAGE_HPP_
+#define JUBATUS_CORE_CLUSTERING_COMPRESSIVE_STORAGE_HPP_
 
 #include <string>
 #include <vector>

--- a/jubatus/core/clustering/compressor.hpp
+++ b/jubatus/core/clustering/compressor.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_COMPRESSOR_COMPRESSOR_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_COMPRESSOR_COMPRESSOR_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_COMPRESSOR_HPP_
+#define JUBATUS_CORE_CLUSTERING_COMPRESSOR_HPP_
 
 #include <msgpack.hpp>
 #include "clustering_config.hpp"

--- a/jubatus/core/clustering/discrete_distribution.hpp
+++ b/jubatus/core/clustering/discrete_distribution.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_UTIL_DISCRETE_DISTRIBUTION_HPP_
-#define JUBATUS_CLUSTERING_UTIL_DISCRETE_DISTRIBUTION_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_DISCRETE_DISTRIBUTION_HPP_
+#define JUBATUS_CORE_CLUSTERING_DISCRETE_DISTRIBUTION_HPP_
 
 #include <vector>
 #include <pficommon/math/random.h>

--- a/jubatus/core/clustering/eigen_feature_mapper.hpp
+++ b/jubatus/core/clustering/eigen_feature_mapper.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTERING_METHOD_GMM_EIGEN_FEATURE_MAPPER_HPP_
-#define JUBATUS_CLUSTERING_CLUSTERING_METHOD_GMM_EIGEN_FEATURE_MAPPER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_EIGEN_FEATURE_MAPPER_HPP_
+#define JUBATUS_CORE_CLUSTERING_EIGEN_FEATURE_MAPPER_HPP_
 
 #include <string>
 #include <utility>

--- a/jubatus/core/clustering/event_dispatcher.hpp
+++ b/jubatus/core/clustering/event_dispatcher.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_EVENT_DISPATCHER_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_EVENT_DISPATCHER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_EVENT_DISPATCHER_HPP_
+#define JUBATUS_CORE_CLUSTERING_EVENT_DISPATCHER_HPP_
 
 #include <map>
 #include <vector>

--- a/jubatus/core/clustering/gmm.hpp
+++ b/jubatus/core/clustering/gmm.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTERING_METHOD_GMM_GMM_HPP_
-#define JUBATUS_CLUSTERING_CLUSTERING_METHOD_GMM_GMM_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_GMM_HPP_
+#define JUBATUS_CORE_CLUSTERING_GMM_HPP_
 
 #include "gmm_types.hpp"
 

--- a/jubatus/core/clustering/gmm_clustering_method.hpp
+++ b/jubatus/core/clustering/gmm_clustering_method.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTER_MANAGER_GMM_CLUSTER_MANAGER_HPP_
-#define JUBATUS_CLUSTERING_CLUSTER_MANAGER_GMM_CLUSTER_MANAGER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_GMM_CLUSTERING_METHOD_HPP_
+#define JUBATUS_CORE_CLUSTERING_GMM_CLUSTERING_METHOD_HPP_
 
 #include <vector>
 #include "clustering_method.hpp"

--- a/jubatus/core/clustering/gmm_compressor.hpp
+++ b/jubatus/core/clustering/gmm_compressor.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_COMPRESSOR_GMM_COMPRESSOR_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_COMPRESSOR_GMM_COMPRESSOR_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_GMM_COMPRESSOR_HPP_
+#define JUBATUS_CORE_CLUSTERING_GMM_COMPRESSOR_HPP_
 
 #include "kmeans_compressor.hpp"
 

--- a/jubatus/core/clustering/gmm_types.hpp
+++ b/jubatus/core/clustering/gmm_types.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTERING_METHOD_GMM_TYPES_HPP_
-#define JUBATUS_CLUSTERING_CLUSTERING_METHOD_GMM_TYPES_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_GMM_TYPES_HPP_
+#define JUBATUS_CORE_CLUSTERING_GMM_TYPES_HPP_
 
 #include <Eigen/Sparse>
 

--- a/jubatus/core/clustering/kmeans_clustering_method.hpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_CLUSTER_MANAGER_KMEANS_CLUSTER_MANAGER_HPP_
-#define JUBATUS_CLUSTERING_CLUSTER_MANAGER_KMEANS_CLUSTER_MANAGER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_KMEANS_CLUSTERING_METHOD_HPP_
+#define JUBATUS_CORE_CLUSTERING_KMEANS_CLUSTERING_METHOD_HPP_
 
 #include <vector>
 #include "clustering_method.hpp"

--- a/jubatus/core/clustering/kmeans_compressor.hpp
+++ b/jubatus/core/clustering/kmeans_compressor.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_COMPRESSOR_KMEANS_COMPRESSOR_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_COMPRESSOR_KMEANS_COMPRESSOR_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_KMEANS_COMPRESSOR_HPP_
+#define JUBATUS_CORE_CLUSTERING_KMEANS_COMPRESSOR_HPP_
 
 #include "compressor.hpp"
 

--- a/jubatus/core/clustering/simple_storage.cpp
+++ b/jubatus/core/clustering/simple_storage.cpp
@@ -17,6 +17,7 @@
 #include "simple_storage.hpp"
 
 #include <string>
+#include <vector>
 
 namespace jubatus {
 namespace core {

--- a/jubatus/core/clustering/simple_storage.hpp
+++ b/jubatus/core/clustering/simple_storage.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_SIMPLE_STORAGE_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_SIMPLE_STORAGE_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_SIMPLE_STORAGE_HPP_
+#define JUBATUS_CORE_CLUSTERING_SIMPLE_STORAGE_HPP_
 
 #include <string>
 #include "storage.hpp"

--- a/jubatus/core/clustering/storage.hpp
+++ b/jubatus/core/clustering/storage.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_STORAGE_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_STORAGE_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_STORAGE_HPP_
+#define JUBATUS_CORE_CLUSTERING_STORAGE_HPP_
 
 #include <fstream>
 #include <iostream>
@@ -59,6 +59,7 @@ class storage : public event_dispatcher<storage_event_type, wplist> {
   virtual void unpack(msgpack::object o);
 
   MSGPACK_DEFINE(revision_, name_, config_, common_);
+
  protected:
   void increment_revision();
 

--- a/jubatus/core/clustering/storage_factory.hpp
+++ b/jubatus/core/clustering/storage_factory.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_STORAGE_FACTORY_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_STORAGE_FACTORY_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_STORAGE_FACTORY_HPP_
+#define JUBATUS_CORE_CLUSTERING_STORAGE_FACTORY_HPP_
 
 #include <string>
 #include <pficommon/lang/shared_ptr.h>

--- a/jubatus/core/clustering/storage_serializer.hpp
+++ b/jubatus/core/clustering/storage_serializer.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_STORAGE_STORAGE_SERIALIZER_HPP_
-#define JUBATUS_CLUSTERING_STORAGE_STORAGE_SERIALIZER_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_STORAGE_SERIALIZER_HPP_
+#define JUBATUS_CORE_CLUSTERING_STORAGE_SERIALIZER_HPP_
 
 #include <string>
 #include "storage.hpp"

--- a/jubatus/core/clustering/testutil.hpp
+++ b/jubatus/core/clustering/testutil.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_TEST_TESTUTIL_HPP_
-#define JUBATUS_CLUSTERING_TEST_TESTUTIL_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_TESTUTIL_HPP_
+#define JUBATUS_CORE_CLUSTERING_TESTUTIL_HPP_
 
 #include <string>
 #include <vector>

--- a/jubatus/core/clustering/types.hpp
+++ b/jubatus/core/clustering/types.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_TYPES_HPP_
-#define JUBATUS_CLUSTERING_TYPES_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_TYPES_HPP_
+#define JUBATUS_CORE_CLUSTERING_TYPES_HPP_
 
 #include <algorithm>
 #include <string>
@@ -31,6 +31,12 @@
 namespace jubatus {
 namespace core {
 namespace clustering {
+
+typedef double cluster_weight;
+typedef std::vector<std::pair<cluster_weight,
+            jubatus::core::fv_converter::datum> > cluster_unit;
+typedef std::vector<cluster_unit> cluster_set;
+
 struct weighted_point {
  public:
   MSGPACK_DEFINE(weight, data, original, free_double, free_long);

--- a/jubatus/core/clustering/util.hpp
+++ b/jubatus/core/clustering/util.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_CLUSTERING_UTIL_UTIL_HPP_
-#define JUBATUS_CLUSTERING_UTIL_UTIL_HPP_
+#ifndef JUBATUS_CORE_CLUSTERING_UTIL_HPP_
+#define JUBATUS_CORE_CLUSTERING_UTIL_HPP_
 
 #include <utility>
 #include <vector>

--- a/jubatus/core/driver/clustering.cpp
+++ b/jubatus/core/driver/clustering.cpp
@@ -55,7 +55,7 @@ datum clustering::get_nearest_center(
       clustering_->get_nearest_center(to_sfv_const(point)));
 }
 
-vector<pair<double, datum> >
+core::clustering::cluster_unit
     clustering::get_nearest_members(const datum& point) const {
   return to_weighted_datum_vector(
       clustering_->get_nearest_members(to_sfv_const(point)));
@@ -65,12 +65,12 @@ vector<datum> clustering::get_k_center() const {
   return to_datum_vector(clustering_->get_k_center());
 }
 
-vector<vector<pair<double, datum> > >
+core::clustering::cluster_set
 clustering::get_core_members() const {
   vector<vector<core::clustering::weighted_point> > src =
       clustering_->get_core_members();
 
-  vector<vector<pair<double, datum> > >  ret;
+  core::clustering::cluster_set ret;
   ret.reserve(src.size());
   std::transform(
       src.begin(), src.end(), std::back_inserter(ret), pfi::lang::bind(
@@ -140,10 +140,10 @@ vector<core::clustering::weighted_point>
   return ret;
 }
 
-vector<pair<double, datum> >
+core::clustering::cluster_unit
   clustering::to_weighted_datum_vector(
     const vector<core::clustering::weighted_point>& src) const {
-  vector<pair<double, datum> > ret;
+  core::clustering::cluster_unit ret;
   ret.reserve(src.size());
   std::transform(src.begin(), src.end(), std::back_inserter(ret),
       pfi::lang::bind(&clustering::to_weighted_datum, this, pfi::lang::_1));

--- a/jubatus/core/driver/clustering.hpp
+++ b/jubatus/core/driver/clustering.hpp
@@ -46,12 +46,11 @@ class clustering {
 
   fv_converter::datum get_nearest_center(
       const fv_converter::datum& point) const;
-  std::vector<std::pair<double, fv_converter::datum> >  get_nearest_members(
+  core::clustering::cluster_unit get_nearest_members(
     const fv_converter::datum& point) const;
 
   std::vector<fv_converter::datum> get_k_center() const;
-  std::vector<std::vector<std::pair<double, fv_converter::datum> > >
-      get_core_members() const;
+  core::clustering::cluster_set get_core_members() const;
 
   size_t get_revision() const;
 
@@ -69,7 +68,7 @@ class clustering {
       const std::vector<common::sfv_t>& src) const;
   std::vector<core::clustering::weighted_point> to_weighted_point_vector(
       const std::vector<fv_converter::datum>& src);
-  std::vector<std::pair<double, fv_converter::datum> > to_weighted_datum_vector(
+  core::clustering::cluster_unit to_weighted_datum_vector(
       const std::vector<core::clustering::weighted_point>& src) const;
 
   pfi::lang::shared_ptr<framework::mixable_holder> mixable_holder_;

--- a/jubatus/server/server/cluster_analysis_serv.hpp
+++ b/jubatus/server/server/cluster_analysis_serv.hpp
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_SERVER_CLUSTER_ANALYSIS_SERV_HPP_
-#define JUBATUS_SERVER_CLUSTER_ANALYSIS_SERV_HPP_
+#ifndef JUBATUS_SERVER_SERVER_CLUSTER_ANALYSIS_SERV_HPP_
+#define JUBATUS_SERVER_SERVER_CLUSTER_ANALYSIS_SERV_HPP_
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
This pull request is for minor revision to clustering and cluster_analysis.
- Type `cluster_weight` , `cluster_unit` and `cluster_set` are explicitly defined.
- Some include guards have been fixed.
