### PR TITLE
Add binary_feature.hpp to plugin.hpp

### DIFF
--- a/jubatus/core/plugin.hpp
+++ b/jubatus/core/plugin.hpp
@@ -21,5 +21,6 @@
 #include <jubatus/core/fv_converter/string_filter.hpp>
 #include <jubatus/core/fv_converter/num_feature.hpp>
 #include <jubatus/core/fv_converter/num_filter.hpp>
+#include <jubatus/core/fv_converter/binary_feature.hpp>
 
 #endif  // JUBATUS_CORE_PLUGIN_HPP_


### PR DESCRIPTION
To develop binary feature plugin, plugin.hpp should include binary_feature.hpp.
