### PR TITLE
add mixer option to jubactl (fix #474)

### DIFF
--- a/jubatus/server/cmd/jubactl.cpp
+++ b/jubatus/server/cmd/jubactl.cpp
@@ -83,6 +83,7 @@ try {
   p.add<int, cmdline::range_reader<int> >("loglevel", 'E',
       "[start] verbosity of log messages", false, google::INFO,
       cmdline::range(google::INFO, google::FATAL));
+  p.add<std::string>("mixer", 'X', "[start] mixer strategy", false, "");
   p.add("join", 'J', "[start] join to the existing cluster");
   p.add<int>("interval_sec", 'S', "[start] mix interval by seconds", false, 16);
   p.add<int>("interval_count", 'I',
@@ -206,6 +207,7 @@ void send2supervisor(
     server_option.datadir = argv.get<std::string>("datadir");
     server_option.logdir = argv.get<std::string>("logdir");
     server_option.loglevel = argv.get<int>("loglevel");
+    server_option.mixer = argv.get<std::string>("mixer");
     server_option.join = argv.exist("join");
 
     server_option.interval_sec = argv.get<int>("interval_sec");

--- a/jubatus/server/framework/server_util.hpp
+++ b/jubatus/server/framework/server_util.hpp
@@ -91,7 +91,7 @@ struct server_argv {
   MSGPACK_DEFINE(join, port, bind_address, bind_if, timeout,
       zookeeper_timeout, interconnect_timeout, threadnum,
       program_name, type, z, name, datadir, logdir, loglevel, eth,
-      interval_sec, interval_count);
+      interval_sec, interval_count, mixer);
 
   bool is_standalone() const {
     return (z == "");

--- a/jubatus/server/jubavisor/process.cpp
+++ b/jubatus/server/jubavisor/process.cpp
@@ -112,6 +112,7 @@ bool process::spawn_link(int p) {
       "-e", lexical_cast<std::string, int>(server_option_.loglevel),
       "-s", lexical_cast<std::string, int>(server_option_.interval_sec),
       "-i", lexical_cast<std::string, int>(server_option_.interval_count),
+      "-x", server_option_.mixer,
     };
     std::vector<const char*> arg_list;
     for (size_t i = 0; i < sizeof(argv) / sizeof(*argv); ++i) {


### PR DESCRIPTION
This fix adds --mixer option support to jubactl & jubavisor. (Fix for #474)
