### PR TITLE
install proxy-related headers only if zookeeper is enabled (fix #517)

### DIFF
--- a/jubatus/server/framework/wscript
+++ b/jubatus/server/framework/wscript
@@ -29,12 +29,17 @@ def build(bld):
       use='jubaserv_framework'
       )
 
-  bld.install_files('${PREFIX}/include/jubatus/server/framework', [
+  header_files = [
+    'save_load.hpp',
+    'server_base.hpp',
+    'server_helper.hpp',
+    'server_util.hpp',
+  ]
+  if bld.env.HAVE_ZOOKEEPER_H:
+    header_files += [
       'proxy.hpp',
       'proxy_common.hpp',
-      'save_load.hpp',
-      'server_base.hpp',
-      'server_helper.hpp',
-      'server_util.hpp',
       'aggregators.hpp'
-      ])
+    ]
+
+  bld.install_files('${PREFIX}/include/jubatus/server/framework', header_files)


### PR DESCRIPTION
Excluded proxy.hp, proxy_common.hpp and aggregators.hpp when --enable-zookeeper is not specified. (fix for #517)

My original goal of the issue #517 is to avoid confusing error message when using jubatus-service-skeleton against Jubatus compiled without ZooKeeper support, and the goal is achieved by this change:

```
../kvs_proxy.cpp:13:46: fatal error: jubatus/server/framework/proxy.hpp: No such file or directory
```
