### PR TITLE
Remove debug print of clustering: fix #544

### DIFF
--- a/jubatus/core/clustering/gmm_clustering_method.cpp
+++ b/jubatus/core/clustering/gmm_clustering_method.cpp
@@ -16,15 +16,12 @@
 
 #include "gmm_clustering_method.hpp"
 
-#include <iostream>
 #include <utility>
 #include <vector>
 #include "../common/exception.hpp"
 #include "util.hpp"
 
 using std::vector;
-using std::cout;
-using std::endl;
 
 namespace jubatus {
 namespace core {
@@ -40,7 +37,6 @@ void gmm_clustering_method::batch_update(wplist points) {
   mapper_.clear();
   eigen_wsvec_list_t data = mapper_.convert(points, true);
   gmm_.batch(data, mapper_.get_dimension(), k_);
-  cout << "center[0]" << gmm_.get_centers()[0] << endl;
   kcenters_ = mapper_.revert(gmm_.get_centers());
 }
 

--- a/jubatus/core/clustering/util.cpp
+++ b/jubatus/core/clustering/util.cpp
@@ -18,7 +18,6 @@
 
 #include <cfloat>
 #include <cmath>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -193,17 +192,6 @@ pair<size_t, double> min_dist(
     }
   }
   return std::make_pair(idx, mindist);
-}
-
-void dump_wplist(const wplist& src) {
-  for (wplist::const_iterator it = src.begin(); it != src.end(); ++it) {
-    std::cout << it->weight << " : ";
-    for (vector<pair<string, float > >::const_iterator itt = it->data.begin();
-         itt != it->data.end(); ++itt) {
-      std::cout << (*itt).second << std::endl;
-    }
-    std::cout << std::endl;
-  }
 }
 
 std::pair<size_t, double> min_dist(const weighted_point& d1, const wplist& P) {


### PR DESCRIPTION
This change removes unnecessary debug print for development of clustering methods to fix #544.
