### PR TITLE
Fix buffer overrun of fixed_size_heap when max_size_==0: fix #573

### DIFF
--- a/jubatus/core/storage/fixed_size_heap.hpp
+++ b/jubatus/core/storage/fixed_size_heap.hpp
@@ -45,7 +45,7 @@ class fixed_size_heap {
         std::make_heap(data_.begin(), data_.end(), comp_);
       }
     } else {
-      if (comp_(v, data_.front())) {
+      if (max_size_ > 0 && comp_(v, data_.front())) {
         std::pop_heap(data_.begin(), data_.end(), comp_);
         data_.back() = v;
         std::push_heap(data_.begin(), data_.end(), comp_);

--- a/jubatus/core/storage/fixed_size_heap_test.cpp
+++ b/jubatus/core/storage/fixed_size_heap_test.cpp
@@ -79,6 +79,16 @@ TEST(fixed_size_heap, reverse) {
   EXPECT_EQ(7, v[2]);
 }
 
+TEST(fixed_size_heap, size_zero) {
+  fixed_size_heap<int> h(0);
+  h.push(1);
+  EXPECT_EQ(0u, h.size());
+
+  vector<int> v;
+  h.get_sorted(v);
+  EXPECT_TRUE(v.empty());
+}
+
 }  // namespace storage
 }  // namespace core
 }  // namespace jubatus


### PR DESCRIPTION
This change fixes #573.
