### PR TITLE
Fix exception catch order to improve portability

### DIFF
--- a/jubatus/core/common/exception.hpp
+++ b/jubatus/core/common/exception.hpp
@@ -281,9 +281,9 @@ inline exception_thrower_ptr get_current_exception() {
     ptr = detail::current_std_exception(e);
   } catch (const std::underflow_error& e) {  // runtime_error
     ptr = detail::current_std_exception(e);
-  } catch (const std::runtime_error& e) {  // exception
-    ptr = detail::current_std_exception(e);
   } catch (const std::ios_base::failure& e) {  // exception
+    ptr = detail::current_std_exception(e);
+  } catch (const std::runtime_error& e) {  // exception
     ptr = detail::current_std_exception(e);
   } catch (const jubatus_exception& e) {
     ptr = e.thrower();


### PR DESCRIPTION
std::ios_base::failure inherits:
- C++98: std::exception
- C++11: std::system_error, which inherits std::runtime_error

so, when using C++11, it generates compiler warnings, because std::runtime_error is catched before std::ios_base::failure.

I reordered the exception catch clause to improve portability at no cost.
