### PR TITLE
Install Eigen

### DIFF
--- a/jubatus/core/third_party/wscript
+++ b/jubatus/core/third_party/wscript
@@ -1,0 +1,15 @@
+import os
+
+def options(opt):
+  pass
+
+def configure(conf):
+  pass
+
+def build(bld):
+  for node in bld.path.ant_glob('Eigen/**/*'):
+      path = node.path_from(bld.path)
+      directory = os.path.dirname(path)
+      bld.install_files(
+          os.path.join('${PREFIX}/include/jubatus/core/third_party', directory),
+          path)

--- a/jubatus/core/wscript
+++ b/jubatus/core/wscript
@@ -1,7 +1,6 @@
 import Options
 
-subdirs = "common anomaly classifier driver framework fv_converter graph recommender regression stat storage nearest_neighbor table clustering"
-
+subdirs = "common anomaly classifier driver framework fv_converter graph recommender regression stat storage nearest_neighbor table clustering third_party"
 def options(opt):
   opt.recurse(subdirs)
 


### PR DESCRIPTION
Eigen headers in `jubatus/core/third_party` are not installed, which disables users to use internal Eigen in binaries linked to shared objects of Jubatus. This PR adds installation of internal Eigen into `${PREFIX}/include/jubatus/core/third_party/Eigen`.

This issue was found through the review of #542, which is blocked by this PR.
