### PR TITLE
Raise exception if unsupported mix strategy name is specified

### DIFF
--- a/jubatus/server/framework/mixer/mixer_factory.cpp
+++ b/jubatus/server/framework/mixer/mixer_factory.cpp
@@ -39,7 +39,7 @@ mixer* create_mixer(
     const jubatus::util::lang::shared_ptr<common::lock_service>& zk) {
 #ifdef HAVE_ZOOKEEPER_H
   const std::string& use_mixer = a.mixer;
-  if (use_mixer.empty() || use_mixer == "linear_mixer") {
+  if (use_mixer == "linear_mixer") {
     return new linear_mixer(
         linear_communication::create(
             zk, a.type, a.name, a.interconnect_timeout),

--- a/jubatus/server/framework/server_util.cpp
+++ b/jubatus/server/framework/server_util.cpp
@@ -128,7 +128,8 @@ server_argv::server_argv(int args, char** argv, const std::string& type)
                      make_ignored_help("learning machine instance name"),
                      false);
   p.add<std::string>("mixer", 'x',
-                     make_ignored_help("mixer strategy"), false, "");
+                     make_ignored_help("mixer strategy"), false,
+                     "linear_mixer");
   p.add("join", 'j', make_ignored_help("join to the existing cluster"));
   p.add<int>("interval_sec", 's',
              make_ignored_help("mix interval by seconds"), false, 16);


### PR DESCRIPTION
This patch fixes https://github.com/jubatus/jubatus/issues/600.

If we specified invalid MIX strategy name using `--mixer, -x` option, server fail to start like followings:

```
F0110 20:17:21.527549 17802 server_util.hpp:143] Dynamic exception type: jubatus::core::common::exception::runtime_error::what: unsupported mix type (no_mixer)
    #0 [jubatus::core::common::exception::error_at_file_*] = ../jubatus/server/framework/mixer/mixer_factory.cpp
    #0 [jubatus::core::common::exception::error_at_line_*] = 62
    #0 [jubatus::core::common::exception::error_at_func_*] = jubatus::server::framework::mixer::mixer* jubatus::server::framework::mixer::create_mixer(const jubatus::server::framework::server_argv&, const jubatus::util::lang::shared_ptr<jubatus::server::common::lock_service>&)
```
