### PR TITLE
fix #619 deleting join option from jubactl and jubavisor

### DIFF
--- a/jubatus/server/cmd/jubactl.cpp
+++ b/jubatus/server/cmd/jubactl.cpp
@@ -84,7 +84,6 @@ try {
       "[start] verbosity of log messages", false, google::INFO,
       cmdline::range(google::INFO, google::FATAL));
   p.add<std::string>("mixer", 'X', "[start] mixer strategy", false, "");
-  p.add("join", 'J', "[start] join to the existing cluster");
   p.add<int>("interval_sec", 'S', "[start] mix interval by seconds", false, 16);
   p.add<int>("interval_count", 'I',
       "[start] mix interval by update count", false, 512);
@@ -208,7 +207,6 @@ void send2supervisor(
     server_option.logdir = argv.get<std::string>("logdir");
     server_option.loglevel = argv.get<int>("loglevel");
     server_option.mixer = argv.get<std::string>("mixer");
-    server_option.join = argv.exist("join");
 
     server_option.interval_sec = argv.get<int>("interval_sec");
     server_option.interval_count = argv.get<int>("interval_count");

--- a/jubatus/server/framework/server_util.hpp
+++ b/jubatus/server/framework/server_util.hpp
@@ -66,7 +66,6 @@ struct server_argv {
   server_argv(int args, char** argv, const std::string& type);
   server_argv();
 
-  bool join;
   int port;
   std::string bind_address;
   std::string bind_if;
@@ -89,7 +88,7 @@ struct server_argv {
   std::string mixer;
   bool daemon;
 
-  MSGPACK_DEFINE(join, port, bind_address, bind_if, timeout,
+  MSGPACK_DEFINE(port, bind_address, bind_if, timeout,
       zookeeper_timeout, interconnect_timeout, threadnum,
       program_name, type, z, name, datadir, logdir, loglevel, eth,
       interval_sec, interval_count, mixer, daemon);

--- a/jubatus/server/jubavisor/process.cpp
+++ b/jubatus/server/jubavisor/process.cpp
@@ -117,9 +117,6 @@ bool process::spawn_link(int p) {
     for (size_t i = 0; i < sizeof(argv) / sizeof(*argv); ++i) {
       arg_list.push_back(argv[i].c_str());
     }
-    if (server_option_.join) {
-      arg_list.push_back("-j");
-    }
     arg_list.push_back(NULL);
 
     execvp(cmd.c_str(), (char* const *) &arg_list[0]);


### PR DESCRIPTION
`--join` option is not needed, only `--zookeeper` and `--name` option is enough.
