### PR TITLE
validate range of --rpc-port option (fix #605)

### DIFF
--- a/jubatus/server/framework/server_util.cpp
+++ b/jubatus/server/framework/server_util.cpp
@@ -101,7 +101,8 @@ server_argv::server_argv(int args, char** argv, const std::string& type)
   google::InitGoogleLogging(argv[0]);
 
   cmdline::parser p;
-  p.add<int>("rpc-port", 'p', "port number", false, 9199);
+  p.add<int>("rpc-port", 'p', "port number", false, 9199,
+             cmdline::range(1, 65535));
   p.add<std::string>("listen_addr", 'b', "bind IP address", false, "");
   p.add<std::string>("listen_if", 'B', "bind network interfance", false, "");
   p.add<int>("thread", 'c', "concurrency = thread number", false, 2);
@@ -337,7 +338,8 @@ proxy_argv::proxy_argv(int args, char** argv, const std::string& t)
   google::InitGoogleLogging(argv[0]);
 
   cmdline::parser p;
-  p.add<int>("rpc-port", 'p', "port number", false, 9199);
+  p.add<int>("rpc-port", 'p', "port number", false, 9199,
+             cmdline::range(1, 65535));
   p.add<std::string>("listen_addr", 'b', "bind IP address", false, "");
   p.add<std::string>("listen_if", 'B', "bind network interfance", false, "");
   p.add<int>("thread", 'c', "concurrency = thread number", false, 16);

--- a/jubatus/server/jubavisor/main.cpp
+++ b/jubatus/server/jubavisor/main.cpp
@@ -48,7 +48,8 @@ void stop_on_term(jubavisor_server& serv) {
 
 int main(int argc, char* argv[]) try {
   cmdline::parser p;
-  p.add<int>("rpc-port", 'p', "port number", false, 9198);
+  p.add<int>("rpc-port", 'p', "port number", false, 9198,
+             cmdline::range(1, 65535));
   p.add<std::string>("zookeeper", 'z', "zookeeper location", true);
   p.add<std::string>("logdir", 'l', "log to output all child process' log",
                      false, "/tmp");


### PR DESCRIPTION
Validate range of --rpc-port option in [1, 65535] (fix #605)
