### PR TITLE
Add name parameter to get_proxy_status

### DIFF
--- a/jubatus/client/common/client.hpp
+++ b/jubatus/client/common/client.hpp
@@ -62,7 +62,7 @@ class client {
 
   std::map<std::string, std::map<std::string, std::string> >
       get_proxy_status() {
-    msgpack::rpc::future f = c_.call("get_proxy_status");
+    msgpack::rpc::future f = c_.call("get_proxy_status", name_);
     return f.get<std::map<std::string, std::map<std::string, std::string> > >();
   }
 


### PR DESCRIPTION
In https://github.com/jubatus/jubatus/commit/e2746d139e2c695ac580a1681eaf109c59493148, I add `get_proxy_status` to client.hpp.

At first, I thought that `name` is not necessary to send. So, I didn't set `name`.
But, If client send `name`, it will be ignored by jubaproxy.

In this patch, I add `name` parameter to `get_proxy_status`.
I unified 2nd parameter of RPC `call` method.
