### PR TITLE
fix classname for jsonconfig::config::iterator::key

### DIFF
--- a/jubatus/core/common/jsonconfig/config.cpp
+++ b/jubatus/core/common/jsonconfig/config.cpp
@@ -38,7 +38,7 @@ config::iterator::iterator(
       it_(it) {
 }
 
-const std::string& config::iterator::iterator::key() const {
+const std::string& config::iterator::key() const {
   return it_->first;
 }
 


### PR DESCRIPTION
The current code works but I think it is not intended.
This patch also improves portability with compilers other than g++.
