### PR TITLE
more test in driver::nearest_neighbor

### DIFF
--- a/jubatus/core/driver/nearest_neighbor_test.cpp
+++ b/jubatus/core/driver/nearest_neighbor_test.cpp
@@ -122,9 +122,9 @@ TEST_P(nearest_neighbor_test, neighbor_row_and_similar_row) {
     nearest_neighbor_->set_row(key, d);
   }
 
-  for (size_t i = 0; i < 200; ++i) {
+  for (size_t i = 0; i < num; ++i) {
     const string key = lexical_cast<string>(i);
-    datum d = single_str_datum("x", key);
+    datum d = single_str_datum("x" + key, "a");
 
     vector<pair<string, float> > nr_result =
         nearest_neighbor_->neighbor_row_from_data(d, 100);


### PR DESCRIPTION
We should test all algorithms `lsh`, `minhash`, `euclid_lsh` with various `hash_num`
And we should call `set_row` `clear` `similar_row` `neighbor_row` methods for all algorithms.

This PR is correspond to #529 
