### PR TITLE
(WIP) throw a exception on cluster methods if it comes before k-means runs

### DIFF
--- a/jubatus/core/clustering/gmm_clustering_method.cpp
+++ b/jubatus/core/clustering/gmm_clustering_method.cpp
@@ -60,10 +60,13 @@ common::sfv_t gmm_clustering_method::get_nearest_center(
 wplist gmm_clustering_method::get_cluster(
     size_t cluster_id,
     const wplist& points) const {
+  if (k_ <= cluster_id) {
+    return wplist();
+  }
   return get_clusters(points)[cluster_id];
 }
 
-std::vector<wplist> gmm_clustering_method::get_clusters(
+vector<wplist> gmm_clustering_method::get_clusters(
     const wplist& points) const {
   std::vector<wplist> ret(k_);
   for (wplist::const_iterator it = points.begin(); it != points.end(); ++it) {

--- a/jubatus/core/clustering/kmeans_clustering_method.cpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include "../common/exception.hpp"
 #include "util.hpp"
+#include "types.hpp"
 
 using std::pair;
 using std::vector;
@@ -99,7 +100,7 @@ vector<common::sfv_t> kmeans_clustering_method::get_k_center() const {
 int64_t kmeans_clustering_method::get_nearest_center_index(
     const common::sfv_t& point) const {
   if (kcenters_.empty()) {
-    throw no_cluster_exception("get_nearest_center_index");
+    throw JUBATUS_EXCEPTION(no_cluster_exception("get_nearest_center_index"));
   }
   return min_dist(point, kcenters_).first;
 }
@@ -107,7 +108,7 @@ int64_t kmeans_clustering_method::get_nearest_center_index(
 common::sfv_t kmeans_clustering_method::get_nearest_center(
     const common::sfv_t& point) const {
   if (kcenters_.empty()) {
-    throw no_cluster_exception("get_nearest_center");
+    throw JUBATUS_EXCEPTION(no_cluster_exception("get_nearest_center"));
   }
   return kcenters_[get_nearest_center_index(point)];
 }
@@ -116,7 +117,7 @@ wplist kmeans_clustering_method::get_cluster(
     size_t cluster_id,
     const wplist& points) const {
   if (kcenters_.empty()) {
-    throw no_cluster_exception("get_cluster");
+    throw JUBATUS_EXCEPTION(no_cluster_exception("get_cluster"));
   }
   if (cluster_id >= k_) {
     return wplist();
@@ -127,7 +128,7 @@ wplist kmeans_clustering_method::get_cluster(
 vector<wplist> kmeans_clustering_method::get_clusters(
     const wplist& points) const {
   if (kcenters_.empty()) {
-    throw no_cluster_exception("get_clusters");
+    throw JUBATUS_EXCEPTION(no_cluster_exception("get_clusters"));
   }
   vector<wplist> ret(k_);
   for (wplist::const_iterator it = points.begin(); it != points.end(); ++it) {

--- a/jubatus/core/clustering/kmeans_clustering_method.cpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.cpp
@@ -93,22 +93,34 @@ void kmeans_clustering_method::online_update(wplist points) {
 }
 
 vector<common::sfv_t> kmeans_clustering_method::get_k_center() const {
+  if (kcenters_.empty()) {
+    throw no_cluster_exception("get_k_center");
+  }
   return kcenters_;
 }
 
 int64_t kmeans_clustering_method::get_nearest_center_index(
     const common::sfv_t& point) const {
+  if (kcenters_.empty()) {
+    throw no_cluster_exception("get_nearest_center_index");
+  }
   return min_dist(point, kcenters_).first;
 }
 
 common::sfv_t kmeans_clustering_method::get_nearest_center(
     const common::sfv_t& point) const {
+  if (kcenters_.empty()) {
+    throw no_cluster_exception("get_nearest_center");
+  }
   return kcenters_[get_nearest_center_index(point)];
 }
 
 wplist kmeans_clustering_method::get_cluster(
     size_t cluster_id,
     const wplist& points) const {
+  if (kcenters_.empty()) {
+    throw no_cluster_exception("get_cluster");
+  }
   if (cluster_id >= k_) {
     return wplist();
   }
@@ -117,6 +129,9 @@ wplist kmeans_clustering_method::get_cluster(
 
 vector<wplist> kmeans_clustering_method::get_clusters(
     const wplist& points) const {
+  if (kcenters_.empty()) {
+    throw no_cluster_exception("get_clusters");
+  }
   vector<wplist> ret(k_);
   for (wplist::const_iterator it = points.begin(); it != points.end(); ++it) {
     pair<int64_t, double> m = min_dist(it->data, kcenters_);

--- a/jubatus/core/clustering/kmeans_clustering_method.cpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.cpp
@@ -93,9 +93,6 @@ void kmeans_clustering_method::online_update(wplist points) {
 }
 
 vector<common::sfv_t> kmeans_clustering_method::get_k_center() const {
-  if (kcenters_.empty()) {
-    throw no_cluster_exception("get_k_center");
-  }
   return kcenters_;
 }
 

--- a/jubatus/core/clustering/kmeans_clustering_method.hpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.hpp
@@ -25,6 +25,18 @@ namespace core {
 namespace clustering {
 
 class clustering_method_serializer;
+class no_cluster_exception : public std::exception {
+ public:
+  no_cluster_exception(const std::string& msg)
+    : what_(msg) {}
+  const char *what() const throw() {
+    return what_.c_str();
+  }
+  ~no_cluster_exception() throw() {}
+
+ private:
+  std::string what_;
+};
 
 class kmeans_clustering_method : public clustering_method {
  public:

--- a/jubatus/core/clustering/kmeans_clustering_method.hpp
+++ b/jubatus/core/clustering/kmeans_clustering_method.hpp
@@ -25,18 +25,6 @@ namespace core {
 namespace clustering {
 
 class clustering_method_serializer;
-class no_cluster_exception : public std::exception {
- public:
-  no_cluster_exception(const std::string& msg)
-    : what_(msg) {}
-  const char *what() const throw() {
-    return what_.c_str();
-  }
-  ~no_cluster_exception() throw() {}
-
- private:
-  std::string what_;
-};
 
 class kmeans_clustering_method : public clustering_method {
  public:

--- a/jubatus/core/clustering/types.hpp
+++ b/jubatus/core/clustering/types.hpp
@@ -26,6 +26,7 @@
 #include "jubatus/util/data/serialization.h"
 
 #include "../common/type.hpp"
+#include "../common/exception.hpp"
 #include "../fv_converter/datum.hpp"
 
 namespace jubatus {
@@ -36,6 +37,20 @@ typedef double cluster_weight;
 typedef std::vector<std::pair<cluster_weight,
             jubatus::core::fv_converter::datum> > cluster_unit;
 typedef std::vector<cluster_unit> cluster_set;
+
+class no_cluster_exception
+  : public common::exception::jubaexception<no_cluster_exception> {
+ public:
+  explicit no_cluster_exception(const std::string& msg)
+    : what_(msg) {}
+  const char *what() const throw() {
+    return what_.c_str();
+  }
+  ~no_cluster_exception() throw() {}
+
+ private:
+  std::string what_;
+};
 
 struct weighted_point {
  public:

--- a/jubatus/core/driver/clustering_test.cpp
+++ b/jubatus/core/driver/clustering_test.cpp
@@ -29,6 +29,7 @@
 #include "../clustering/gmm_clustering_method.hpp"
 #include "test_util.hpp"
 #include "../fv_converter/datum.hpp"
+#include "../clustering/types.hpp"
 
 using std::vector;
 using std::string;
@@ -37,6 +38,7 @@ using std::set;
 using std::make_pair;
 using jubatus::util::lang::shared_ptr;
 using jubatus::core::fv_converter::datum;
+using jubatus::core::clustering::no_cluster_exception;
 using jubatus::core::clustering::clustering_method;
 using jubatus::core::clustering::clustering_config;
 
@@ -114,6 +116,17 @@ TEST_P(clustering_test, save_load) {
   msgpack::unpacked unpacked;
   msgpack::unpack(&unpacked, sbuf.data(), sbuf.size());
   clustering_->get_mixable_holder()->unpack(unpacked.get());
+}
+
+TEST_P(clustering_test, no_cluster) {
+  core::fv_converter::datum d;
+  vector<datum> datums;
+  datums.push_back(single_datum("a", 1));
+  clustering_->push(datums);
+
+  ASSERT_THROW(clustering_->get_nearest_members(d), no_cluster_exception);
+  ASSERT_THROW(clustering_->get_nearest_center(d), no_cluster_exception);
+  ASSERT_THROW(clustering_->get_core_members(), no_cluster_exception);
 }
 
 TEST_P(clustering_test, get_k_center) {


### PR DESCRIPTION
This PR is correspond to #667 

Some clustering RPC cause segfault before it runs clustering calculation.
We should check `kcenters_` before access it.