### PR TITLE
Detect IO errors in save

### DIFF
--- a/jubatus/server/framework/server_base.cpp
+++ b/jubatus/server/framework/server_base.cpp
@@ -65,7 +65,7 @@ void load_file_impl(server_base& server,
     ifs.close();
   } catch (const std::ios_base::failure&) {
     throw JUBATUS_EXCEPTION(
-      core::common::exception::runtime_error("cannot read output file")
+      core::common::exception::runtime_error("cannot read input file")
       << core::common::exception::error_file_name(path)
       << core::common::exception::error_errno(errno));
   }


### PR DESCRIPTION
If system is disk-full, `save` return no error (And, broken file is outputted) in 0.5.2.

This patch will solve that problem.
- Detect i/o error and raise an exception
- Print log about the cause of exception using `errno`

And I changed log message of `load` as same with `save`.
