### PR TITLE
don't mix when no update observed, fix #181

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -361,7 +361,8 @@ void linear_mixer::stabilizer_loop() {
       }
       const clock_time new_ticktime = get_clock_time();
       if (((0 < count_threshold_ && counter_ >= count_threshold_)
-          || (0 < tick_threshold_ && new_ticktime - ticktime_ > tick_threshold_))
+          || (0 < tick_threshold_
+              && new_ticktime - ticktime_ > tick_threshold_))
           && (0 < counter_)) {
         if (zklock->try_lock()) {
           LOG(INFO) << "starting mix:";


### PR DESCRIPTION
This PR is correspond to #181 

If no update was done, we shouldn't invoke mix.
#### discussion
- Push_mixer should invoke mix without observing update.
- Because every node should propagate update of others.
- No node could detect the demands of mix without mix.
