### PR TITLE
use uint64_t instead of size_t to prevent overflow (#692)

### DIFF
--- a/jubatus/core/fv_converter/keyword_weights.hpp
+++ b/jubatus/core/fv_converter/keyword_weights.hpp
@@ -38,7 +38,7 @@ class keyword_weights {
     return document_frequencies_[key];
   }
 
-  size_t get_document_count() const {
+  uint64_t get_document_count() const {
     return document_count_;
   }
 
@@ -62,7 +62,7 @@ class keyword_weights {
  private:
   double get_global_weight(const std::string& key) const;
 
-  size_t document_count_;
+  uint64_t document_count_;
   counter<std::string> document_frequencies_;
   typedef jubatus::util::data::unordered_map<std::string, float> weight_t;
   weight_t weights_;

--- a/jubatus/core/fv_converter/weight_manager.hpp
+++ b/jubatus/core/fv_converter/weight_manager.hpp
@@ -95,7 +95,7 @@ class weight_manager {
   }
 
  private:
-  size_t get_document_count() const {
+  uint64_t get_document_count() const {
     return diff_weights_.get_document_count() +
         master_weights_.get_document_count();
   }


### PR DESCRIPTION
FIx for #692.
Maximum value of `size_t` depends on CPU arch, so `document_count_` may overflow when models saved in 64-bit with more than 2^32 `document_count_` are loaded onto 32-bit.

This fix does not break compatibility for existing model files (0.5.0+).
