### PR TITLE
avoid infinite loop in `get_model` fix #711

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -131,8 +131,8 @@ size_t linear_communication_impl::update_members() {
 }
 
 byte_buffer linear_communication_impl::get_model() {
+  update_members();
   for (;;) {
-    update_members();
     common::unique_lock lk(m_);
 
     // use time as pseudo random number(it should enough)


### PR DESCRIPTION
fix #711 

We should include `update_members()` in model getting loop.
So that Jubatus can detect the change of membership in retrying.

And each retry, the node should release the zk_lock.
