### PR TITLE
Fix RPC error handling in linear_mixer: fixes #729

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -230,7 +230,13 @@ string create_error_string(const msgpack::object& error) {
         case ARGUMENT_ERROR:
           return "argument error";
         default:
-          return "unknown error";
+          {
+            string msg = "unknown remote error (";
+            msg += jubatus::util::lang::lexical_cast<string>(
+                error.as<unsigned int>());
+            msg += ")";
+            return msg;
+          }
       }
 
     case msgpack::type::NEGATIVE_INTEGER:


### PR DESCRIPTION
Patch for #729.
