### PR TITLE
Print log when error occurred during proxy is forwarding requests

### DIFF
--- a/jubatus/server/framework/proxy.hpp
+++ b/jubatus/server/framework/proxy.hpp
@@ -672,6 +672,13 @@ class proxy
     }
 
     Res aggregate_results() {
+      if (errors_.size() != 0) {
+        LOG(WARNING) << "error occurred in " << errors_.size()
+                     << " out of " << futures_.size() << " requests";
+        LOG(WARNING) << jubatus::server::common::mprpc::to_string(
+            jubatus::server::common::mprpc::error_multi_rpc(errors_));
+      }
+
       if (results_.size() == 0) {
         return Res();  // TODO(kmaehashi): we should raise exception ?
       }


### PR DESCRIPTION
As a first step of #503, I added logs when error occurred during `Proxy` is forwarding requests.

If servers return RPC error in `save`, proxy output log as followings: 

```
W0325 18:14:43.401207 16497 proxy.hpp:676] error occurred in 2 out of 3 requests
W0325 18:14:43.401346 16497 proxy.hpp:678] rpc_error with 2 servers
 host: xx.x.xxx.xxx, port: 9003
   Dynamic exception type: jubatus::server::common::mprpc::rpc_call_error
       #0 [jubatus::server::common::mprpc::error_method_*] = save
       #0 [jubatus::core::common::exception::error_message_*] = rpc_server error: "cannot open output file"
 host: xx.x.xxx.xxx, port: 9001
   Dynamic exception type: jubatus::server::common::mprpc::rpc_call_error
       #0 [jubatus::server::common::mprpc::error_method_*] = save
       #0 [jubatus::core::common::exception::error_message_*] = rpc_server error: "cannot open output file"
```

[NOTE] At this time, server output log as followings:

```
W0325 18:14:43.400441 16418 rpc_server.cpp:46] Dynamic exception type: jubatus::core::common::exception::runtime_error::what: cannot open output file
    #0 [jubatus::core::common::exception::error_file_name_*] = /var/data/jubatus/xx.x.xxx.xxx_9003_jubatus_id.jubatus
    #0 [jubatus::core::common::exception::error_errno_*] = Permission denied (13)
    #0 [jubatus::core::common::exception::error_at_file_*] = ../jubatus/server/framework/server_base.cpp
    #0 [jubatus::core::common::exception::error_at_line_*] = 98
    #0 [jubatus::core::common::exception::error_at_func_*] = virtual bool jubatus::server::framework::server_base::save(const string&)
```
