### PR TITLE
Fix MIX success log to be printed only when success at least 1 server

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -466,7 +466,8 @@ void linear_mixer::mix() {
           mixable_holder_->get_mixables();
 
       vector<vector<byte_buffer> > diffs;
-      {  // get_diff() -> diffs
+      // get_diff() -> diffs
+      {
         common::mprpc::rpc_result_object result;
         communication_->get_diff(result);
 
@@ -488,16 +489,16 @@ void linear_mixer::mix() {
               make_pair(result.error[i].host(), result.error[i].port()));
         }
 
-        {  // success info message
-          LOG(INFO) << "success to get_diff from ["
-                    << server_list(successes) << "]";
+        if (diffs.empty()) {
+          throw JUBATUS_EXCEPTION(
+              core::common::exception::runtime_error("no diff available"));
         }
+
+        // success info message
+        LOG(INFO) << "success to get_diff from ["
+                  << server_list(successes) << "]";
       }
 
-      if (diffs.empty()) {
-        throw JUBATUS_EXCEPTION(
-            core::common::exception::runtime_error("no diff available"));
-      }
 
       vector<byte_buffer> mixed = diffs.front();
       diffs.erase(diffs.begin());


### PR DESCRIPTION
When MIX (get_diff) was failed on all the servers, `success to get_diff from` message is always printed.
This is redundant.

```
W0514 11:55:36.150894 19321 linear_mixer.cpp:462] get_diff failed at 192.168.122.211:9199 : connect failed
I0514 11:55:36.150946 19321 linear_mixer.cpp:474] success to get_diff from []
W0514 11:55:36.151079 19321 linear_mixer.cpp:529] mix failed :no diff available
```
