### PR TITLE
Improve get_model RPC error handling

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -152,10 +152,17 @@ byte_buffer linear_communication_impl::get_model() {
 
     msgpack::rpc::client cli(server_ip, server_port);
     msgpack::rpc::future result(cli.call("get_model", 0));
-    const byte_buffer got_model_data(result.get<byte_buffer>());
-    LOG(INFO) << "got model(serialized data) " << got_model_data.size()
-              << " from server[" << server_ip << ":" << server_port << "] ";
-    return got_model_data;
+
+    try {
+      const byte_buffer got_model_data(result.get<byte_buffer>());
+      LOG(INFO) << "got model(serialized data) " << got_model_data.size()
+                << " from server[" << server_ip << ":" << server_port << "] ";
+      return got_model_data;
+    } catch (const std::runtime_error& e) {
+      LOG(WARNING) << "get_model failed (" << e.what() << "): "
+                   << server_ip << ":" << server_port;
+      throw;
+    }
   }
 }
 


### PR DESCRIPTION
`get_model` does not handle connection errors, so it does not contain server/port actually failed, which prohibits the logging policy.

Before applying this patch:

```
I0514 17:04:40.945291  1258 linear_mixer.cpp:413] start to get model from other server
W0514 17:04:49.955059  1258 linear_mixer.cpp:425] stabilizer exception: connect failed
```

After applying this patch:

```
I0514 18:16:37.019196  5300 linear_mixer.cpp:399] start to get model from other server
W0514 18:16:46.031011  5300 linear_mixer.cpp:164] get_model failed (connect failed): 192.168.122.211:9199
W0514 18:16:46.031390  5300 linear_mixer.cpp:411] stabilizer exception: connect failed
```
