### PR TITLE
Fix build without --enable-zookeeper to work

### DIFF
--- a/jubatus/server/framework/mixer/dummy_mixer.hpp
+++ b/jubatus/server/framework/mixer/dummy_mixer.hpp
@@ -44,6 +44,10 @@ class dummy_mixer : public mixer {
 
   void get_status(server_base::status_t& status) const {
   }
+
+  std::string type() const {
+    return "dummy_mixer";
+  }
 };
 
 }  // namespace mixer


### PR DESCRIPTION
Issue #754 introduced pure virtual `std::string type() const` in mixable class, however dummy_mixer did not implement it.

This caused CI configure variation test (pattern without --enable-zookeeper) to fail: http://ci.jubat.us/job/develop_configure/904/testReport/%28root%29/configure/
