### PR TITLE
Fix jenerator for jubatus_core

### DIFF
--- a/tools/jenerator/src/cpp.ml
+++ b/tools/jenerator/src/cpp.ml
@@ -722,7 +722,7 @@ let gen_server_template_header names s =
       (1,   "virtual ~" ^ serv_name ^ "();  // do not change");
       (0,   "");
       (1,   "virtual jubatus::server::framework::mixer::mixer* get_mixer() const;");
-      (1,   "jubatus::util::lang::shared_ptr<jubatus::core::framework::mixable_holder> get_mixable_holder() const;");
+      (1,   "virtual jubatus::core::driver::driver_base* get_driver() const;");
       (1,   "std::string get_config() const;");
       (1,   "uint64_t user_data_version() const;");
       (1,   "void get_status(status_t& status) const;");
@@ -733,7 +733,7 @@ let gen_server_template_header names s =
     [
       (0, "");
       (0, " private:");
-      (1,   "// add user data here like: jubatus::util::lang::shared_ptr<some_type> some_;");
+      (1,   "// add user defined driver like: jubatus::util::lang::shared_ptr<some_type> some_;");
       (0, "};")
     ]
   ]
@@ -782,9 +782,6 @@ let gen_server_template_source names s =
       (1,   "const jubatus::server::framework::server_argv& a,");
       (1,   "const jubatus::util::lang::shared_ptr<jubatus::server::common::lock_service>& zk)");
       (2,     ": jubatus::server::framework::server_base(a) {");
-      (1,   "// somemixable* mi = new somemixable;");
-      (1,   "// somemixable_.set_model(mi);");
-      (1,   "// get_mixable_holder()->register_mixable(mi);");
       (0, "}");
       (0, "");
       (0, serv_name ^ "::~" ^ serv_name ^ "() {");
@@ -793,8 +790,7 @@ let gen_server_template_source names s =
       (0, "jubatus::server::framework::mixer::mixer* " ^ serv_name ^ "::get_mixer() const {");
       (0, "}");
       (0, "");
-      (0, "jubatus::util::lang::shared_ptr<jubatus::core::framework::mixable_holder> "
-        ^ serv_name ^ "::get_mixable_holder() const {");
+      (0, "jubatus::core::driver::driver_base* " ^ serv_name ^ "::get_driver() const {");
       (0, "}");
       (0, "");
       (0, "std::string " ^ serv_name ^ "::get_config() const {");


### PR DESCRIPTION
I modified that generates server template  for jubatus_core separation.
This PR doesn't affect exisintg client and proxy codes.
