### PR TITLE
Fix unittest_gtest to run after vnum setup (server)

### DIFF
--- a/unittest_gtest.py
+++ b/unittest_gtest.py
@@ -164,6 +164,7 @@ class utest(Task.Task):
     Execute a unit test
     """
     color = 'PINK'
+    after = ['vnum','inst']
     ext_in = ['.bin']
     vars = []
     def runnable_status(self):


### PR DESCRIPTION
Pull in upstream fix as proposed in https://github.com/tanakh/waf-unittest/pull/10
