### PR TITLE
Add -lpthread to avoid linking error.

### DIFF
--- a/jubatus/server/server/wscript
+++ b/jubatus/server/server/wscript
@@ -25,7 +25,8 @@ def build_one(bld, name, libraries = '', sources = ''):
       source = '%s_proxy.cpp ' % name,
       target = 'juba%s_proxy' % name,
       includes = '.',
-      use = 'jubatus_util JUBATUS_CORE jubaserv_framework jubaserv_fv_converter jubaserv_common jubaserv_mprpc_common JUBATUS_MPIO JUBATUS_MSGPACK-RPC MSGPACK'
+      use = 'jubatus_util JUBATUS_CORE jubaserv_framework jubaserv_fv_converter jubaserv_common jubaserv_mprpc_common JUBATUS_MPIO JUBATUS_MSGPACK-RPC MSGPACK',
+      linkflags = '-lpthread'
       )
 
 def build(bld):


### PR DESCRIPTION
Linking proxies fail when build on Ubuntu 13.10 or Debian sid.
So we add "linkflags = "-lpthread'" to wscript for now.
This may be a bad idea, so we have to seek another solution.
