### PR TITLE
Add a build option for sanitizer.

### DIFF
--- a/wscript
+++ b/wscript
@@ -41,6 +41,10 @@ def options(opt):
                  action='store_true', default=False,
                  dest='disable_eigen', help='disable internal Eigen and algorithms using it')
 
+  opt.add_option('--fsanitize',
+                 action='store', default="",
+                 dest='fsanitize', help='specify sanitizer')
+
   opt.recurse(subdirs)
 
 def configure(conf):
@@ -119,6 +123,11 @@ def configure(conf):
   conf.env.USE_EIGEN = not Options.options.disable_eigen
   if conf.env.USE_EIGEN:
     conf.define('JUBATUS_USE_EIGEN', 1)
+
+  sanitizer_names = Options.options.fsanitize
+  if len(sanitizer_names) > 0:
+    conf.env.append_unique('CXXFLAGS', '-fsanitize=' + sanitizer_names)
+    conf.env.append_unique('LINKFLAGS', '-fsanitize=' + sanitizer_names)
 
   conf.recurse(subdirs)
 


### PR DESCRIPTION
This request relates to #835 and https://github.com/jubatus/jubatus_core/pull/29.

Usage:

```
./waf configure --fsanitize=memory
```

More than one sanitizer can be specified:

```
./waf configure --fsanitize=thread,undefined
```

Read http://clang.llvm.org/docs/UsersManual.html#controlling-code-generation for datails.
