### PR TITLE
add timeout for get_model RPC (fix #720)

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -156,6 +156,7 @@ byte_buffer linear_communication_impl::get_model() {
     }
 
     msgpack::rpc::client cli(server_ip, server_port);
+    cli.set_timeout(timeout_sec_);
     msgpack::rpc::future result(cli.call("get_model", 0));
 
     try {


### PR DESCRIPTION
Fix #720 
The timeout can now be given via the command line parameter `--interconnect_timeout`.
