### PR TITLE
Unlock during trying to get ZK-lock

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -368,8 +368,10 @@ void linear_mixer::stabilizer_loop() {
           || (0 < tick_threshold_
               && new_ticktime - ticktime_ > tick_threshold_))
           && (0 < counter_)) {
+        lk.unlock();
         if (zklock->try_lock()) {
           LOG(INFO) << "got ZooKeeper lock, starting mix";
+          common::unique_lock lk(m_);
           counter_ = 0;
           ticktime_ = new_ticktime;
 
@@ -383,7 +385,9 @@ void linear_mixer::stabilizer_loop() {
       }
 
       if (is_obsolete_) {
+        lk.unlock();
         if (zklock->try_lock()) {
+          common::unique_lock lk(m_);
           if (is_obsolete_) {
             LOG(INFO) << "start to get model from other server";
             lk.unlock();


### PR DESCRIPTION
This PR is the patch for #618.

I tested this patch in below condition:
- Number of `jubaclassifier` process: 4
- Number of RPC thread: 4
- MIX interval count: 1000
- Number of Client: 96
- Ratio of `train` and `classifier`: 10 : 90

Result is followings:

|  | QPS | MAX CPU Usage | MIX count per 10 min |
| --- | --- | --- | --- |
| w/ this patch | 23836.75 | 79% | 325 |
| wo/ this patch | 12806.05 | 56% | 193 |
