### PR TITLE
Fix wscript to compile crc32.cpp.

### DIFF
--- a/jubatus/server/common/wscript
+++ b/jubatus/server/common/wscript
@@ -24,10 +24,10 @@ int main() {
 
 def build(bld):
   import Options
-  src = 'network.cpp global_id_generator_standalone.cpp config.cpp signals.cpp system.cpp filesystem.cpp'
+  src = 'network.cpp global_id_generator_standalone.cpp config.cpp signals.cpp system.cpp filesystem.cpp crc32.cpp'
 
   if bld.env.HAVE_ZOOKEEPER_H:
-    src += ' cached_zk.cpp zk.cpp membership.cpp cht.cpp lock_service.cpp global_id_generator_zk.cpp crc32.cpp'
+    src += ' cached_zk.cpp zk.cpp membership.cpp cht.cpp lock_service.cpp global_id_generator_zk.cpp'
 
   bld.shlib(
     source = src,


### PR DESCRIPTION
When crc32.cpp was not compiled when --enable-zookeeper is not specified, but crc32.cpp is used always.
