### PR TITLE
fix thread ID to be displayed on OS X (fix #874)

### DIFF
--- a/jubatus/server/common/logger/logger.cpp
+++ b/jubatus/server/common/logger/logger.cpp
@@ -34,11 +34,15 @@
 
 #define LOGGER_NAME "jubatus"
 
+namespace {
+
 #ifdef __APPLE__
-#define SYSCALL_GET_THREAD_ID SYS_thread_selfid
+const int gettid = SYS_thread_selfid;
 #else
-#define SYSCALL_GET_THREAD_ID SYS_gettid
+const int gettid = SYS_gettid;
 #endif
+
+}  // namespace
 
 using jubatus::util::lang::lexical_cast;
 
@@ -65,7 +69,7 @@ stream_logger::stream_logger(
       file_(file),
       line_(line),
       abort_(abort),
-      thread_id_(::syscall(SYSCALL_GET_THREAD_ID)) {}
+      thread_id_(::syscall(gettid)) {}
 
 stream_logger::~stream_logger() {
   log4cxx::MDC::put("tid", lexical_cast<std::string>(thread_id_));


### PR DESCRIPTION
This patch fixes #874.

Thread number is now printed correctly (instead of -1) on OS X:

```
2014-11-19 17:22:15,492 365180 INFO  [server_util.cpp:361] starting jubaclassifier 0.6.4 RPC server at 192.168.21.1:9199
2014-11-19 17:22:30,349 365192 INFO  [server_base.cpp:129] starting save to /private/tmp/192.168.21.1_9199_classifier_foo.jubatus
```

This value matches with the thread ID (`tid`) shown in lldb, so it is useful for debugging:

```
(lldb) thread list
Process 2856 stopped
* thread #1: tid = 0x5927c, 0x00007fff89a0aa3a libsystem_kernel.dylib`__semwait_signal + 10, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  thread #2: tid = 0x59286, 0x00007fff89a0acc2 libsystem_kernel.dylib`__sigwait + 10
  thread #3: tid = 0x59287, 0x00007fff89a0b64a libsystem_kernel.dylib`kevent + 10
  thread #4: tid = 0x59288, 0x00007fff89a0a716 libsystem_kernel.dylib`__psynch_cvwait + 10
```
