### PR TITLE
reopen ZK log files on SIGHUP signal (fix #876)

### DIFF
--- a/jubatus/server/common/lock_service.hpp
+++ b/jubatus/server/common/lock_service.hpp
@@ -81,6 +81,8 @@ class lock_service {
   virtual const std::string& get_hosts() const = 0;
   virtual const std::string type() const = 0;
   virtual const std::string get_connected_host_and_port() const = 0;
+
+  virtual void reopen_logfile() = 0;
 };
 
 class try_lockable : public jubatus::util::concurrent::lockable {

--- a/jubatus/server/common/zk.cpp
+++ b/jubatus/server/common/zk.cpp
@@ -90,8 +90,8 @@ zk::zk(const string& hosts, int timeout, const string& logfile)
     throw JUBATUS_EXCEPTION(
         core::common::exception::runtime_error(
             "failed to initialize zk: " + hosts)
-        << core::common::exception::error_api_func("zookeeper_init")
-        << core::common::exception::error_errno(errno));
+            << core::common::exception::error_api_func("zookeeper_init")
+            << core::common::exception::error_errno(errno));
   }
 
   if (!wait_until_connected(timeout)) {
@@ -107,7 +107,7 @@ zk::zk(const string& hosts, int timeout, const string& logfile)
 zk::~zk() {
   force_close();
   if (log_fp_) {
-    zoo_set_log_stream(NULL); // print to stderr
+    zoo_set_log_stream(NULL);  // print to stderr
     fclose(log_fp_);
     log_fp_ = NULL;
   }
@@ -125,9 +125,9 @@ void zk::reopen_logfile() {
     if (!log_fp_) {
       throw JUBATUS_EXCEPTION(
           core::common::exception::runtime_error("cannot open zk logfile")
-          << core::common::exception::error_file_name(log_file_)
-          << core::common::exception::error_errno(errno)
-          << core::common::exception::error_api_func("fopen"));
+              << core::common::exception::error_file_name(log_file_)
+              << core::common::exception::error_errno(errno)
+              << core::common::exception::error_api_func("fopen"));
     }
     ::zoo_set_log_stream(log_fp_);
     if (old_log_fp_ != NULL) {
@@ -456,8 +456,9 @@ const std::string zk::get_connected_host_and_port() const {
   if (zookeeper_get_connected_host(zh_, &sock_addr, &sock_len) == NULL) {
     throw JUBATUS_EXCEPTION(
       core::common::exception::runtime_error("cannot get connected host")
-      << core::common::exception::error_api_func("zookeeper_get_connected_host")
-      << core::common::exception::error_message(zerror(errno)));
+          << core::common::exception::error_api_func(
+              "zookeeper_get_connected_host")
+          << core::common::exception::error_message(zerror(errno)));
   }
 
   // TODO(@rimms): add this code to common::util

--- a/jubatus/server/common/zk.hpp
+++ b/jubatus/server/common/zk.hpp
@@ -85,6 +85,7 @@ class zk : public lock_service {
   const std::string type() const;
 
   const std::string get_connected_host_and_port() const;
+  void reopen_logfile();
 
  protected:
   bool list_(const std::string& path, std::vector<std::string>& out);
@@ -96,7 +97,8 @@ class zk : public lock_service {
   jubatus::util::concurrent::mutex m_;
   std::vector<jubatus::util::lang::function<void()> > cleanups_;
 
-  FILE* logfilep_;
+  const std::string log_file_;
+  FILE* log_fp_;
 };
 
 // TODO(kashihara): write zk mock and test them all?

--- a/jubatus/server/framework/mixer/push_mixer_test.cpp
+++ b/jubatus/server/framework/mixer/push_mixer_test.cpp
@@ -128,6 +128,8 @@ class zk_stub : public common::lock_service {
   virtual const std::string get_connected_host_and_port() const {
     return "";
   }
+  virtual void reopen_logfile() {
+  }
 };
 
 }  // namespace

--- a/jubatus/server/framework/server_util.cpp
+++ b/jubatus/server/framework/server_util.cpp
@@ -80,6 +80,10 @@ void configure_logger(const std::string& log_config) {
     ::exit(1);
   }
 
+  if (ls) {
+    ls->reopen_logfile();
+  }
+
   logger_configured_ = true;
   common::set_action_on_hup(jubatus::util::lang::bind(
       configure_logger, jubatus::util::lang::ref(log_config)));


### PR DESCRIPTION
This fixes #876; now ZK logs can be rotated by external tools like logrotate.