### PR TITLE
Dockerfile for jabatus base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# jubatus base image
+FROM ubuntu:12.04
+
+# install the latest jubatus
+RUN echo "deb http://download.jubat.us/apt binary/" >> /etc/apt/sources.list.d/jubatus.list
+RUN apt-get -y update
+RUN apt-get --force-yes -y install jubatus
+
+# set environment variables from /opt/jubatus/profile
+ENV JUBATUS_HOME /opt/jubatus
+ENV PATH ${JUBATUS_HOME}/bin:${PATH}
+ENV LD_LIBRARY_PATH ${JUBATUS_HOME}/lib:${LD_LIBRARY_PATH}
+ENV LDFLAGS -L${JUBATUS_HOME}/lib ${LDFLAGS}
+ENV CPLUS_INCLUDE_PATH ${JUBATUS_HOME}/include:${CPLUS_INCLUDE_PATH}
+ENV PKG_CONFIG_PATH ${JUBATUS_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}


### PR DESCRIPTION
If jabatus published a public base image, this would help newbies very efficiently.

This just performs:
* based on ubuntu 12.04 LTS 64bit (ubuntu:12.04)
* install the latest jabatus
* set required environment variables from /opt/jubatus/profile

_CAUTION: Because I'm not sure who is an appropriate maintainer, this Dockerfile doesn't include MAINTAINER clause. Jubatus committer could add the clause later._