### PR TITLE
generation management of clear and load

### DIFF
--- a/jubatus/server/framework/proxy_common.cpp
+++ b/jubatus/server/framework/proxy_common.cpp
@@ -116,7 +116,8 @@ create_lock(shared_ptr<common::lock_service>& zk,
       new common::lock_service_mutex(*zk, path + "/master_lock"));
 }
 
-shared_ptr<common::lock_service_mutex> proxy_common::get_master_lockable(const string& name) {
+shared_ptr<common::lock_service_mutex>
+proxy_common::get_master_lockable(const string& name) {
   return create_lock(zk_, a_.type, name);
 }
 

--- a/jubatus/server/framework/proxy_common.hpp
+++ b/jubatus/server/framework/proxy_common.hpp
@@ -58,6 +58,9 @@ class proxy_common {
       const std::string& name,
       std::vector<std::pair<std::string, int> >& ret);
 
+  util::lang::shared_ptr<common::lock_service_mutex> get_master_lockable(
+      const std::string& name);
+
   void get_members_from_cht_(
       const std::string& name,
       const std::string& id,


### PR DESCRIPTION
fix issue #757 

On broadcasting RPC, master lock of jubatus cluster should be required for avoiding to interleave of broadcasting and MIX.