### PR TITLE
Fix memory leak.

### DIFF
--- a/jubatus/server/common/zk.cpp
+++ b/jubatus/server/common/zk.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include "jubatus/util/concurrent/lock.h"
 #include "jubatus/util/data/string/utility.h"
+#include "jubatus/util/lang/noncopyable.h"
 #include "jubatus/core/common/assert.hpp"
 #include "jubatus/core/common/exception.hpp"
 
@@ -337,7 +338,7 @@ bool zk::list(const string& path, vector<string>& out) {
 
 namespace {
 
-class string_vector_holder {
+class string_vector_holder : util::lang::noncopyable {
  public:
   string_vector_holder()
     : v_()  // set null

--- a/jubatus/server/common/zk.cpp
+++ b/jubatus/server/common/zk.cpp
@@ -340,8 +340,7 @@ namespace {
 class string_vector_holder {
  public:
   string_vector_holder()
-    : v_()  // set null (deallocate_String_vector does nothing
-            // when null is passed.)
+    : v_()  // set null
   {}
 
   ~string_vector_holder() {
@@ -349,11 +348,9 @@ class string_vector_holder {
   }
 
   int zoo_get_children(zhandle_t* zh, const char* path, int watch) {
-    if (v_.data != 0) {
-      // this behavior may break strong exception safety,
-      // but such case is user's fault.
-      release();
-    }
+    // releasing memory here may break strong exception safety,
+    // but such case is user's fault.
+    release();
     return ::zoo_get_children(zh, path, watch, &v_);
   }
 
@@ -366,7 +363,10 @@ class string_vector_holder {
   }
 
   void release() {
-    deallocate_String_vector(&v_);
+    if (v_.data != 0) {
+      deallocate_String_vector(&v_);
+      v_.data = 0;
+    }
   }
 
  private:

--- a/jubatus/server/common/zk.cpp
+++ b/jubatus/server/common/zk.cpp
@@ -367,6 +367,7 @@ class string_vector_holder : util::lang::noncopyable {
     if (v_.data != 0) {
       deallocate_String_vector(&v_);
       v_.data = 0;
+      v_.count = 0;
     }
   }
 


### PR DESCRIPTION
Fixed #911.
zoo_get_children() returns allocated memory implicitly.
