### PR TITLE
support combination feature

### DIFF
--- a/jubatus/server/fv_converter/dynamic_combination_feature.cpp
+++ b/jubatus/server/fv_converter/dynamic_combination_feature.cpp
@@ -18,6 +18,8 @@
 
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace jubatus {
 namespace server {

--- a/jubatus/server/fv_converter/dynamic_combination_feature.cpp
+++ b/jubatus/server/fv_converter/dynamic_combination_feature.cpp
@@ -1,0 +1,44 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "dynamic_combination_feature.hpp"
+
+#include <map>
+#include <string>
+
+namespace jubatus {
+namespace server {
+namespace fv_converter {
+
+dynamic_combination_feature::dynamic_combination_feature(
+    const std::string& path,
+    const std::string& function,
+    const std::map<std::string, std::string>& params)
+    : loader_(path),
+      impl_(load_object<combination_feature>(loader_, function, params)) {
+}
+
+void dynamic_combination_feature::add_feature(
+      const std::string& key,
+      double value_left,
+      double value_right,
+      std::vector<std::pair<std::string, float> >& ret_fv) const {
+  impl_->add_feature(key, value_left, value_right, ret_fv);
+}
+
+}  // namespace fv_converter
+}  // namespace server
+}  // namespace jubatus

--- a/jubatus/server/fv_converter/dynamic_combination_feature.hpp
+++ b/jubatus/server/fv_converter/dynamic_combination_feature.hpp
@@ -1,0 +1,54 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_SERVER_FV_CONVERTER_DYNAMIC_COMBINATION_FEATURE_HPP_
+#define JUBATUS_SERVER_FV_CONVERTER_DYNAMIC_COMBINATION_FEATURE_HPP_
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+#include "jubatus/util/lang/scoped_ptr.h"
+#include "dynamic_loader.hpp"
+#include "jubatus/core/fv_converter/combination_feature.hpp"
+
+namespace jubatus {
+namespace server {
+namespace fv_converter {
+
+class dynamic_combination_feature : public core::fv_converter::combination_feature {
+ public:
+  dynamic_combination_feature(
+      const std::string& path,
+      const std::string& function,
+      const std::map<std::string, std::string>& params);
+
+  void add_feature(
+      const std::string& key,
+      double value_left,
+      double value_right,
+      std::vector<std::pair<std::string, float> >& ret_fv) const;
+
+ private:
+  dynamic_loader loader_;
+  jubatus::util::lang::scoped_ptr<core::fv_converter::combination_feature> impl_;
+};
+
+}  // namespace fv_converter
+}  // namespace server
+}  // namespace jubatus
+
+#endif  // JUBATUS_SERVER_FV_CONVERTER_DYNAMIC_COMBINATION_FEATURE_HPP_

--- a/jubatus/server/fv_converter/dynamic_combination_feature.hpp
+++ b/jubatus/server/fv_converter/dynamic_combination_feature.hpp
@@ -29,7 +29,8 @@ namespace jubatus {
 namespace server {
 namespace fv_converter {
 
-class dynamic_combination_feature : public core::fv_converter::combination_feature {
+class dynamic_combination_feature
+    : public core::fv_converter::combination_feature {
  public:
   dynamic_combination_feature(
       const std::string& path,
@@ -44,7 +45,8 @@ class dynamic_combination_feature : public core::fv_converter::combination_featu
 
  private:
   dynamic_loader loader_;
-  jubatus::util::lang::scoped_ptr<core::fv_converter::combination_feature> impl_;
+  jubatus::util::lang::scoped_ptr<core::fv_converter::combination_feature>
+      impl_;
 };
 
 }  // namespace fv_converter

--- a/jubatus/server/fv_converter/so_factory.cpp
+++ b/jubatus/server/fv_converter/so_factory.cpp
@@ -20,11 +20,13 @@
 
 #include "dynamic_string_filter.hpp"
 #include "dynamic_binary_feature.hpp"
+#include "dynamic_combination_feature.hpp"
 #include "dynamic_num_feature.hpp"
 #include "dynamic_num_filter.hpp"
 #include "dynamic_string_feature.hpp"
 
 using jubatus::core::fv_converter::binary_feature;
+using jubatus::core::fv_converter::combination_feature;
 using jubatus::core::fv_converter::num_filter;
 using jubatus::core::fv_converter::num_feature;
 using jubatus::core::fv_converter::string_feature;
@@ -43,6 +45,17 @@ binary_feature* so_factory::create_binary_feature(
     const std::string& path = get_or_die(params, "path");
     const std::string& function = get_or_die(params, "function");
     return new dynamic_binary_feature(path, function, params);
+  }
+  return NULL;
+}
+
+combination_feature* so_factory::create_combination_feature(
+    const std::string& name,
+    const param_t& params) const {
+  if (name == "dynamic") {
+    const std::string& path = get_or_die(params, "path");
+    const std::string& function = get_or_die(params, "function");
+    return new dynamic_combination_feature(path, function, params);
   }
   return NULL;
 }

--- a/jubatus/server/fv_converter/so_factory.hpp
+++ b/jubatus/server/fv_converter/so_factory.hpp
@@ -31,6 +31,10 @@ class so_factory : public core::fv_converter::factory_extender {
         const std::string& name,
         const core::fv_converter::param_t&) const;
 
+  core::fv_converter::combination_feature* create_combination_feature(
+      const std::string& name,
+      const core::fv_converter::param_t&) const;
+
   core::fv_converter::num_filter*
     create_num_filter(
         const std::string& name,

--- a/jubatus/server/fv_converter/wscript
+++ b/jubatus/server/fv_converter/wscript
@@ -22,6 +22,7 @@ def build(bld):
       'dynamic_binary_feature.cpp',
       'dynamic_string_filter.cpp',
       'dynamic_num_filter.cpp',
+      'dynamic_combination_feature.cpp',
       ]
 
   bld.shlib(

--- a/jubatus/server/server/nearest_neighbor_serv.cpp
+++ b/jubatus/server/server/nearest_neighbor_serv.cpp
@@ -17,6 +17,7 @@
 #include "nearest_neighbor_serv.hpp"
 
 #include <string>
+#include <vector>
 #include "jubatus/util/concurrent/lock.h"
 #include "jubatus/util/lang/cast.h"
 #include "jubatus/util/text/json.h"


### PR DESCRIPTION
CI will fail because `jubatus_core`'s so_file.hpp force to inherit `combination_feature()` function.
`combination_feature` is newly supported via issue [104](https://github.com/jubatus/jubatus_core/pull/104)