### PR TITLE
[jenerator]refactor parse test

### DIFF
--- a/tools/jenerator/.gitignore
+++ b/tools/jenerator/.gitignore
@@ -1,7 +1,9 @@
 *.a
+*.cmo
 *.cmxa
 jdl_lexer.ml
 jdl_parser.ml
 jdl_parser.mli
 jenerator
 jenerator.opt
+oUnit-anon.cache

--- a/tools/jenerator/src/OMakefile
+++ b/tools/jenerator/src/OMakefile
@@ -6,7 +6,7 @@ clean:
 
 USE_OCAMLFIND = true
 #
-OCAMLPACKS[] = extlib
+OCAMLPACKS[] = extlib ppx_deriving.show
 #    pack1
 #    pack2
 #

--- a/tools/jenerator/src/syntax.ml
+++ b/tools/jenerator/src/syntax.ml
@@ -29,24 +29,26 @@ type decl_type =
   | List of decl_type
   | Map of decl_type * decl_type
   | Nullable of decl_type
+  [@@deriving show]
 ;;
 
 type field_type = {
   field_number: int;
   field_type: decl_type;
   field_name: string;
-};;
+} [@@deriving show];;
 
-type routing_type = | Random | Cht of int | Broadcast | Internal;;
+type routing_type = | Random | Cht of int | Broadcast | Internal [@@deriving show];;
 
-type reqtype = | Update | Analysis | Nolock;;
+type reqtype = | Update | Analysis | Nolock [@@deriving show];;
 
-type aggtype = | All_and | All_or | Concat | Merge | Ignore | Pass;;
+type aggtype = | All_and | All_or | Concat | Merge | Ignore | Pass [@@deriving show];;
 
 type decorator_type =
   | Routing of routing_type
   | Reqtype of reqtype
   | Aggtype of aggtype
+  [@@deriving show]
 ;;
 
 type method_type = {
@@ -54,7 +56,7 @@ type method_type = {
   method_name: string;
   method_arguments: field_type list;
   method_decorators: decorator_type list;
-};;
+} [@@deriving show];;
 
 let get_decorator m =
   match m.method_decorators with
@@ -67,24 +69,24 @@ let get_decorator m =
 type service_type = {
   service_name: string;
   service_methods: method_type list;
-};;
+} [@@deriving show];;
 
 type enum_type = {
   enum_name: string;
   enum_values: (int * string) list;
-};;
+} [@@deriving show];;
 
 type message_type = {
   message_name: string;
   message_fields: field_type list;
   message_raw: string option;
-};;
+} [@@deriving show];;
 
 type exception_type = {
   exception_name: string;
   exception_fields: field_type list;
   exception_super: string option;
-};;
+} [@@deriving show];;
 
 type statement =
   | Include of string
@@ -92,16 +94,17 @@ type statement =
   | Message of message_type
   | Exception of exception_type
   | Service of service_type
+  [@@deriving show]
 ;;
 
-type idl = statement list;;
+type idl = statement list [@@deriving show];;
 
 type program = {
   enums: enum_type list;
   messages: message_type list;
   exceptions: exception_type list;
   services: service_type list;
-};;
+} [@@deriving show];;
 
 exception Unknown_type of string;;
 

--- a/tools/jenerator/test/OMakefile
+++ b/tools/jenerator/test/OMakefile
@@ -11,7 +11,7 @@ FILES[] =
   lib_test
 
 USE_OCAMLFIND = true
-OCAMLPACKS[] = oUnit str extlib
+OCAMLPACKS[] = oUnit str extlib ppx_deriving.show
 
 PROGRAM = test
 OCAML_LIBS += ../src/target

--- a/tools/jenerator/test/parse_test.ml
+++ b/tools/jenerator/test/parse_test.ml
@@ -1,32 +1,58 @@
 open OUnit
 open Syntax
 
-let parse_error_position_test program line character =
+type result =
+  | Success of idl
+  | LexError of int * int * char
+  | ParseError of int * int
+
+let result_to_string = function
+  | Success(_) -> "Success(<abst>)" (* TODO: implement idl_to_string *)
+  | LexError(lnum, cnum, ch) -> Printf.sprintf "LexError(%n, %n, '%c')" lnum cnum ch
+  | ParseError(lnum, cnum) -> Printf.sprintf "ParseError(%n, %n)" lnum cnum
+
+let parse program =
   let lexbuf = Lexing.from_string program in
   try
-    let _ = Parse.parse lexbuf in
-    assert_failure "This IDL must cause an error."
+    Success(Parse.parse lexbuf)
   with
   | Parse.Syntax_error pos ->
-    assert_equal line pos.Lexing.pos_lnum;
-    assert_equal character (pos.Lexing.pos_cnum - pos.Lexing.pos_bol)
+    Lexing.(
+      ParseError(pos.pos_lnum, pos.pos_cnum - pos.pos_bol)
+    )
+  | Jdl_lexer.Illegal_character(pos, ch) ->
+    Lexing.(
+      LexError(pos.pos_lnum, pos.pos_cnum - pos.pos_bol, ch)
+    )
 ;;
+
+let parse_test program expected =
+  assert_equal ~printer:result_to_string expected @@ parse program
+;;
+
+let parse_error_position_test program lnum cnum =
+  parse_test program @@ ParseError(lnum, cnum)
+;;
+
+let lex_error_position_test program lnum cnum ch =
+  parse_test program @@ LexError(lnum, cnum, ch)
+;;
+
+let parse_success_test program idl =
+  parse_test program @@ Success(idl)
 
 let _ = run_test_tt_main begin "parser" >::: [
   "test_parse_error_position" >:: begin fun() ->
+    parse_error_position_test "" 1 0;
     parse_error_position_test "  here" 1 2;
     parse_error_position_test "# comment\n here" 2 1
   end;
 
   "test_illegal_character" >:: begin fun() ->
-    let lexbuf = Lexing.from_string "  $" in
-    try
-      let _ = Parse.parse lexbuf in
-      assert_failure "This IDL must cause an error."
-    with
-    | Jdl_lexer.Illegal_character(pos, ch) ->
-      assert_equal 1 pos.Lexing.pos_lnum;
-      assert_equal 2 (pos.Lexing.pos_cnum - pos.Lexing.pos_bol);
-      assert_equal '$' ch
+    lex_error_position_test "  $" 1 2 '$'
   end;
+
+  "test_parse_success" >:: begin fun() ->
+    parse_success_test "%include \"test\"" [Include("test")]
+  end
 ] end

--- a/tools/jenerator/test/parse_test.ml
+++ b/tools/jenerator/test/parse_test.ml
@@ -5,11 +5,7 @@ type result =
   | Success of idl
   | LexError of int * int * char
   | ParseError of int * int
-
-let result_to_string = function
-  | Success(_) -> "Success(<abst>)" (* TODO: implement idl_to_string *)
-  | LexError(lnum, cnum, ch) -> Printf.sprintf "LexError(%n, %n, '%c')" lnum cnum ch
-  | ParseError(lnum, cnum) -> Printf.sprintf "ParseError(%n, %n)" lnum cnum
+  [@@deriving show]
 
 let parse program =
   let lexbuf = Lexing.from_string program in
@@ -27,7 +23,7 @@ let parse program =
 ;;
 
 let parse_test program expected =
-  assert_equal ~printer:result_to_string expected @@ parse program
+  assert_equal ~printer:show_result expected @@ parse program
 ;;
 
 let parse_error_position_test program lnum cnum =


### PR DESCRIPTION
# Abstruct
- add `result` type and extract `parse` method
- add successful test
- add `*.cmo` and `oUnit-anon.cache` to gitignore
- add `ppx_deriving` to test printer
  - see https://github.com/whitequark/ppx_deriving

# Requirement
- Ocaml >= 4.02.0
- `ppx_deriving` library(`opam install ppx_deriving`)