### PR TITLE
fix RPC port range used for test

### DIFF
--- a/jubatus/server/wscript
+++ b/jubatus/server/wscript
@@ -5,17 +5,6 @@ common framework cmd jubavisor server fv_converter third_party
 '''
 
 def options(opt):
-  opt.add_option('--enable-zookeeper',
-                 action='store_true', default=False, # dest='nozk',
-                 help='use ZooKeeper')
-  opt.add_option('--enable-zktest',
-                 action='store_true', default=False, 
-                 dest='zktest', help='zk should run in localhost:2181')
-  # use (base + 10) ports for RPC module tests
-  opt.add_option('--rpc-test-port-base',
-                 default=60023, choices=map(str, xrange(1024, 65535 - 10)),
-                 help='base port number for RPC module tests')
-
   opt.recurse(subdirs)
 
 def configure(conf):

--- a/wscript
+++ b/wscript
@@ -35,7 +35,7 @@ def options(opt):
 
   # use (base + 10) ports for RPC module tests
   opt.add_option('--rpc-test-port-base',
-                 default=60023, choices=map(str, xrange(1024, 65535 - 10)),
+                 default=61023, choices=map(str, xrange(1024, 65535 - 10)),
                  help='base port number for RPC module tests')
 
   opt.add_option('--fsanitize',


### PR DESCRIPTION
I am intentionally sending this pull-req to master branch, as it strongly impacts the operation of CI server.

Most Linux systems use port range of 32768-61000 for ephemeral (source) ports.
This may possible cause `address in use` error, so we should avoid using them for tests.

This also fixes #922.