### PR TITLE
add jubatus_core dependency to jenerator test

### DIFF
--- a/tools/jenerator/test/test.sh
+++ b/tools/jenerator/test/test.sh
@@ -5,6 +5,6 @@ pushd testwork
 ../../src/jenerator -l server -t ../sample.idl -n toolong::name::space
 mv sample_serv.tmpl.cpp sample_serv.cpp
 mv sample_serv.tmpl.hpp sample_serv.hpp
-g++ -Wall -o sample_server sample_serv.cpp sample_impl.cpp `pkg-config --cflags --libs jubatus`
-g++ -Wall -o small_proxy sample_proxy.cpp `pkg-config --cflags --libs jubatus`
+g++ -Wall -o sample_server sample_serv.cpp sample_impl.cpp `pkg-config --cflags --libs jubatus_core jubatus`
+g++ -Wall -o small_proxy sample_proxy.cpp `pkg-config --cflags --libs jubatus_core jubatus`
 popd


### PR DESCRIPTION
Current jenerator test fails as dependency to `jubatus_core` is not specified.

```
/usr/bin/ld: /tmp/ccvE5HEb.o: undefined reference to symbol 'jubatus::core::common::exception::jubatus_exception::diagnostic_information(bool) const'
/usr/bin/ld: note: 'jubatus::core::common::exception::jubatus_exception::diagnostic_information(bool) const' is defined in DSO /opt/jubatus/lib/libjubatus_core.so.0 so try adding it to the linker command line
/opt/jubatus/lib/libjubatus_core.so.0: could not read symbols: Invalid operation
```
