### PR TITLE
do not lock mixer on `get_status()`

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -344,7 +344,6 @@ void linear_mixer::updated() {
 }
 
 void linear_mixer::get_status(server_base::status_t& status) const {
-  scoped_lock lk(m_);
   status["linear_mixer.count"] =
       jubatus::util::lang::lexical_cast<string>(counter_);
   // since last mix


### PR DESCRIPTION
`get_status` function only does reads two atomic variable.
the atomicity of these two values are not important.
remove lock. fix #912 