### PR TITLE
Prevent SEGV in mix.

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -476,7 +476,7 @@ void linear_mixer::mix() {
                 diff_result.error[i].host(), diff_result.error[i].port()));
         }
 
-        if (diff == 0) { // all get_diffs fail
+        if (diff == 0) {  // all get_diffs fail
           LOG(WARNING) << "mix fails (all get_diffs fail)";
           return;
         }

--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -476,7 +476,7 @@ void linear_mixer::mix() {
                 diff_result.error[i].host(), diff_result.error[i].port()));
         }
 
-        if (diff == 0) {  // all get_diffs fail
+        if (!diff) {  // all get_diffs fail
           LOG(WARNING) << "mix fails (all get_diffs fail)";
           return;
         }

--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -476,6 +476,11 @@ void linear_mixer::mix() {
                 diff_result.error[i].host(), diff_result.error[i].port()));
         }
 
+        if (diff == 0) { // all get_diffs fail
+          LOG(WARNING) << "mix fails (all get_diffs fail)";
+          return;
+        }
+
         // success info message
         LOG(INFO) << "success to get_diff from ["
                   << server_list(successes) << "]";


### PR DESCRIPTION
`linear_mixer::mix()` fails when all `get_diff`s fail.
It is meaningless to call `put_diff` when all `get_diff`s fail, so I modified `linear_mixer::mix()` not to call `put_diff`s.
