### PR TITLE
Stop printing verbose log from cpplint.

### DIFF
--- a/wscript
+++ b/wscript
@@ -181,7 +181,10 @@ def cpplint(ctx):
   tmp_file = tempfile.NamedTemporaryFile(delete=True);
   tmp_file.write("\n".join(file_list));
   tmp_file.flush()
-  ctx.exec_command('cat ' + tmp_file.name + ' | xargs "' + cpplint.abspath() + '" --filter=-runtime/references,-runtime/rtti 2>&1')
+  sys.stderr.write('Running cpplint...\n')
+  ctx.exec_command('cat ' + tmp_file.name +
+                   ' | xargs "' + cpplint.abspath() + '" --filter=-runtime/references,-runtime/rtti 2>&1' +
+                   ' | grep -v "^Done processing "')
   tmp_file.close()
 
 def regenerate(ctx):


### PR DESCRIPTION
Fixes #951.