### PR TITLE
clean up nearest_neighbor status values (fix #883)

### DIFF
--- a/jubatus/server/server/nearest_neighbor_serv.cpp
+++ b/jubatus/server/server/nearest_neighbor_serv.cpp
@@ -58,7 +58,8 @@ nearest_neighbor_serv::nearest_neighbor_serv(
     const framework::server_argv& a,
     const shared_ptr<common::lock_service>& zk)
     : server_base(a),
-      mixer_(create_mixer(a, zk, rw_mutex(), user_data_version())) {
+      mixer_(create_mixer(a, zk, rw_mutex(), user_data_version())),
+      update_row_cnt_(0) {
 }
 
 nearest_neighbor_serv::~nearest_neighbor_serv() {
@@ -66,10 +67,7 @@ nearest_neighbor_serv::~nearest_neighbor_serv() {
 
 void nearest_neighbor_serv::get_status(status_t& status) const {
   status_t my_status;
-  my_status["clear_row_cnt"] = lexical_cast<string>(clear_row_cnt_);
   my_status["update_row_cnt"] = lexical_cast<string>(update_row_cnt_);
-  my_status["build_cnt"] = lexical_cast<string>(build_cnt_);
-  my_status["mix_cnt"] = lexical_cast<string>(mix_cnt_);
   my_status["data"] = lexical_cast<string>(
       nearest_neighbor_->get_table()->dump_json());
   status.insert(my_status.begin(), my_status.end());
@@ -120,10 +118,7 @@ std::string nearest_neighbor_serv::get_config() const {
 bool nearest_neighbor_serv::clear() {
   DLOG(INFO) << __func__;
   check_set_config();
-  clear_row_cnt_ = 0;
   update_row_cnt_ = 0;
-  build_cnt_ = 0;
-  mix_cnt_ = 0;
   nearest_neighbor_->clear();
   return true;
 }

--- a/jubatus/server/server/nearest_neighbor_serv.hpp
+++ b/jubatus/server/server/nearest_neighbor_serv.hpp
@@ -72,10 +72,7 @@ class nearest_neighbor_serv : public framework::server_base {
 
   std::string config_;
 
-  uint64_t clear_row_cnt_;
   uint64_t update_row_cnt_;
-  uint64_t build_cnt_;
-  uint64_t mix_cnt_;
 
   jubatus::util::lang::shared_ptr<core::driver::nearest_neighbor>
     nearest_neighbor_;


### PR DESCRIPTION
This patch fixes #883.

* Currently, build_cnt, clear_row_cnt, mix_cnt are unused and uninitialized.
  I removed these values.
* Currently, update_row_cnt is *used* but uninitialized.
  I fixed the value to initialize with 0.