### PR TITLE
Fix run_server to use std::cerr when logger is not configured

### DIFF
--- a/jubatus/server/framework/server_util.hpp
+++ b/jubatus/server/framework/server_util.hpp
@@ -142,11 +142,20 @@ int run_server(int args, char** argv, const std::string& type) {
     }
     return impl_server.run();
   } catch (const jubatus::core::common::exception::jubatus_exception& e) {
-    LOG(FATAL) << "exception in main thread: "
-               << e.diagnostic_information(true);
+    if (common::logger::is_configured()) {
+      LOG(FATAL) << "exception in main thread: "
+                 << e.diagnostic_information(true);
+    } else {
+      std::cerr << "exception in main thread: "
+                << e.diagnostic_information(true);
+    }
     return -1;
   } catch (const std::exception& e) {
-    LOG(FATAL) << "error in main thread: " << e.what();
+    if (common::logger::is_configured()) {
+      LOG(FATAL) << "error in main thread: " << e.what();
+    } else {
+      std::cerr << "error in main thread: " << e.what();
+    }
     return -1;
   }
 }


### PR DESCRIPTION
related issue: https://github.com/jubatus/jubatus/issues/982