### PR TITLE
support non-commutative functions in combination feature

### DIFF
--- a/jubatus/server/fv_converter/dynamic_combination_feature.cpp
+++ b/jubatus/server/fv_converter/dynamic_combination_feature.cpp
@@ -41,6 +41,10 @@ void dynamic_combination_feature::add_feature(
   impl_->add_feature(key, value_left, value_right, ret_fv);
 }
 
+bool dynamic_combination_feature::is_commutative() const {
+  return impl_->is_commutative();
+}
+
 }  // namespace fv_converter
 }  // namespace server
 }  // namespace jubatus

--- a/jubatus/server/fv_converter/dynamic_combination_feature.hpp
+++ b/jubatus/server/fv_converter/dynamic_combination_feature.hpp
@@ -43,6 +43,12 @@ class dynamic_combination_feature
       double value_right,
       std::vector<std::pair<std::string, float> >& ret_fv) const;
 
+  /**
+   * Return true if the add_feature function is commutative with any
+   * left/right key.
+   */
+  bool is_commutative() const;
+
  private:
   dynamic_loader loader_;
   jubatus::util::lang::scoped_ptr<core::fv_converter::combination_feature>


### PR DESCRIPTION
Support non-commutative combination functions in plug-ins.

This patch must be merged after https://github.com/jubatus/jubatus_core/pull/156.