### PR TITLE
workaround debuginfo issue (refs #970)

### DIFF
--- a/tools/packaging/rpm/rpmbuild/jubatus-core/SPECS/jubatus-core.spec.in
+++ b/tools/packaging/rpm/rpmbuild/jubatus-core/SPECS/jubatus-core.spec.in
@@ -46,6 +46,7 @@ This package provides headers and libraries needed of Jubatus Core.
 %install
 %{__rm} -rf %{buildroot}
 %{__waf} install --destdir=%{buildroot}
+find %{buildroot}/%{_libdir} -name "lib*.so*" -exec chmod 755 {} \;
 
 %clean
 %{__rm} -rf %{buildroot}

--- a/tools/packaging/rpm/rpmbuild/jubatus/SPECS/jubatus.spec.in
+++ b/tools/packaging/rpm/rpmbuild/jubatus/SPECS/jubatus.spec.in
@@ -73,6 +73,7 @@ This package provides Jubatus C++ client headers.
 %install
 %{__rm} -rf %{buildroot}
 %{__waf} install --destdir=%{buildroot}
+find %{buildroot}/%{_libdir} -name "lib*.so*" -exec chmod 755 {} \;
 
 %clean
 %{__rm} -rf %{buildroot}


### PR DESCRIPTION
Currently jubatus-core-debuginfo and jubatus-debuginfo RPM packages does not provide complete debug information, as pointed in #970.
As a workaround until we migrate to the newer version of waf, add execution permission manually in SPEC file.