### PR TITLE
fix nearest_neighbor.idl not installed (fix #1009)

### DIFF
--- a/jubatus/server/server/wscript
+++ b/jubatus/server/server/wscript
@@ -1,5 +1,4 @@
 # -*- python -*-
-idls = ['classifier.idl', 'regression.idl', 'recommender.idl', 'stat.idl', 'graph.idl', 'anomaly.idl', 'bandit.idl', 'burst.idl', 'clustering.idl']
 
 def options(opt):
   pass
@@ -41,4 +40,5 @@ def build(bld):
   build_one(bld, "burst")
   build_one(bld, "bandit")
 
-  bld.install_files('${PREFIX}/share/jubatus/idl/', idls)
+  bld.install_files('${PREFIX}/share/jubatus/idl/',
+                    map(lambda x: x + '.idl', bld.env['JUBATUS_ENGINES']))

--- a/wscript
+++ b/wscript
@@ -8,6 +8,18 @@ VERSION = '0.7.2'
 ABI_VERSION = VERSION
 APPNAME = 'jubatus'
 
+JUBATUS_ENGINES = [
+                   'anomaly',
+                   'bandit',
+                   'burst',
+                   'classifier',
+                   'clustering',
+                   'graph',
+                   'nearest_neighbor',
+                   'recommender',
+                   'regression',
+                  ]
+
 top = '.'
 out = 'build'
 subdirs = ['config', 'jubatus', 'plugin']
@@ -62,6 +74,7 @@ def configure(conf):
   # Version constants
   conf.env.VERSION = VERSION
   conf.env.ABI_VERSION = ABI_VERSION
+  conf.env.JUBATUS_ENGINES = JUBATUS_ENGINES
 
   conf.check_cxx(lib = 'msgpack')
   conf.check_cxx(lib = 'jubatus_mpio')


### PR DESCRIPTION
Fix #1009.

I moved the engine list to the root wscript. I intend to use `JUBATUS_ENGINES` variable in `man/wscript` in the next patch.