### PR TITLE
Bandit: CHT replication level should be 1

### DIFF
--- a/jubatus/server/server/anomaly_client.hpp
+++ b/jubatus/server/server/anomaly_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_CLIENT_HPP_

--- a/jubatus/server/server/anomaly_impl.cpp
+++ b/jubatus/server/server/anomaly_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/anomaly_proxy.cpp
+++ b/jubatus/server/server/anomaly_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/anomaly_types.hpp
+++ b/jubatus/server/server/anomaly_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_TYPES_HPP_

--- a/jubatus/server/server/bandit.idl
+++ b/jubatus/server/server/bandit.idl
@@ -38,7 +38,7 @@ service bandit {
   #-
   #- Each player is assigned a set of slot machines.
   #- When asked, the server determines which arm (slot mechine) would be the best to pull, based on a multi-armed bandit algorithm.
-  #@cht #@update #@pass
+  #@cht(1) #@update #@pass
   string select_arm(0: string player_id)
 
   #- - Parameters:
@@ -53,7 +53,7 @@ service bandit {
   #-
   #- Register observed reward to the server.
   #- If assume_unrewarded option is true, there is no need to register reward when it is zero.
-  #@cht #@update #@all_and
+  #@cht(1) #@update #@all_and
   bool register_reward(0: string player_id, 1: string arm_id, 2: double reward)
 
   #- - Parameters:
@@ -65,7 +65,7 @@ service bandit {
   #-  - list of slot machine states.
   #-
   #- Retrieve the states of slot machines, assigned to a designated player.
-  #@cht #@analysis #@pass
+  #@cht(1) #@analysis #@pass
   map<string, arm_info> get_arm_info(0: string player_id)
 
   #- - Parameters:

--- a/jubatus/server/server/bandit_impl.cpp
+++ b/jubatus/server/server/bandit_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-33-g6c0f737) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/bandit_proxy.cpp
+++ b/jubatus/server/server/bandit_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-33-g6c0f737) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -24,13 +24,13 @@ int run_proxy(int argc, char* argv[]) {
     k.register_async_broadcast<bool, std::string>("delete_arm",
         jubatus::util::lang::function<bool(bool, bool)>(
         &jubatus::server::framework::all_and));
-    k.register_async_cht<2, std::string>("select_arm",
+    k.register_async_cht<1, std::string>("select_arm",
         jubatus::util::lang::function<std::string(std::string, std::string)>(
         &jubatus::server::framework::pass<std::string>));
-    k.register_async_cht<2, bool, std::string, double>("register_reward",
+    k.register_async_cht<1, bool, std::string, double>("register_reward",
         jubatus::util::lang::function<bool(bool, bool)>(
         &jubatus::server::framework::all_and));
-    k.register_async_cht<2, std::map<std::string, arm_info> >("get_arm_info",
+    k.register_async_cht<1, std::map<std::string, arm_info> >("get_arm_info",
         jubatus::util::lang::function<std::map<std::string, arm_info>(
         std::map<std::string, arm_info>, std::map<std::string, arm_info>)>(
         &jubatus::server::framework::pass<std::map<std::string, arm_info> >));

--- a/jubatus/server/server/bandit_types.hpp
+++ b/jubatus/server/server/bandit_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-33-g6c0f737) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_BANDIT_TYPES_HPP_

--- a/jubatus/server/server/burst_impl.cpp
+++ b/jubatus/server/server/burst_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/burst_proxy.cpp
+++ b/jubatus/server/server/burst_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/burst_types.hpp
+++ b/jubatus/server/server/burst_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_BURST_TYPES_HPP_

--- a/jubatus/server/server/classifier_impl.cpp
+++ b/jubatus/server/server/classifier_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/classifier_proxy.cpp
+++ b/jubatus/server/server/classifier_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/classifier_types.hpp
+++ b/jubatus/server/server/classifier_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_CLASSIFIER_TYPES_HPP_

--- a/jubatus/server/server/clustering_impl.cpp
+++ b/jubatus/server/server/clustering_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/clustering_proxy.cpp
+++ b/jubatus/server/server/clustering_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/clustering_types.hpp
+++ b/jubatus/server/server/clustering_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_CLUSTERING_TYPES_HPP_

--- a/jubatus/server/server/graph_client.hpp
+++ b/jubatus/server/server/graph_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_GRAPH_CLIENT_HPP_

--- a/jubatus/server/server/graph_impl.cpp
+++ b/jubatus/server/server/graph_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/graph_proxy.cpp
+++ b/jubatus/server/server/graph_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/graph_types.hpp
+++ b/jubatus/server/server/graph_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_GRAPH_TYPES_HPP_

--- a/jubatus/server/server/nearest_neighbor_impl.cpp
+++ b/jubatus/server/server/nearest_neighbor_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.6.4-33-gf65b203) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from nearest_neighbor.idl(0.6.4-33-gf65b203) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/nearest_neighbor_proxy.cpp
+++ b/jubatus/server/server/nearest_neighbor_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.6.4-33-gf65b203) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from nearest_neighbor.idl(0.6.4-33-gf65b203) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/nearest_neighbor_types.hpp
+++ b/jubatus/server/server/nearest_neighbor_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.6.4-33-gf65b203) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from nearest_neighbor.idl(0.6.4-33-gf65b203) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_NEAREST_NEIGHBOR_TYPES_HPP_

--- a/jubatus/server/server/recommender_impl.cpp
+++ b/jubatus/server/server/recommender_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/recommender_proxy.cpp
+++ b/jubatus/server/server/recommender_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/recommender_types.hpp
+++ b/jubatus/server/server/recommender_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_RECOMMENDER_TYPES_HPP_

--- a/jubatus/server/server/regression_impl.cpp
+++ b/jubatus/server/server/regression_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/regression_proxy.cpp
+++ b/jubatus/server/server/regression_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/regression_types.hpp
+++ b/jubatus/server/server/regression_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_REGRESSION_TYPES_HPP_

--- a/jubatus/server/server/stat_impl.cpp
+++ b/jubatus/server/server/stat_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/stat_proxy.cpp
+++ b/jubatus/server/server/stat_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/stat_types.hpp
+++ b/jubatus/server/server/stat_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.7.1-14-g79178f8/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.6.4-146-g79178f8/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_STAT_TYPES_HPP_


### PR DESCRIPTION
Currently, CHT replication level of the following methods are ``2``.
* ``select_arm``
* ``register_reward``

So, reward will be registered twice in Jubatus-Cluster.

This patch will solve this problem.
