### PR TITLE
Add status info to linear_mixer

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -349,6 +349,10 @@ void linear_mixer::get_status(server_base::status_t& status) const {
   // since last mix
   status["linear_mixer.ticktime"] =
       jubatus::util::lang::lexical_cast<string>(ticktime_.sec);
+  status["linear_mixer.is_obsolete"] =
+      jubatus::util::lang::lexical_cast<string>(is_obsolete_);
+  status["linear_mixer.is_running"] =
+      jubatus::util::lang::lexical_cast<string>(is_running_);
 }
 
 void linear_mixer::stabilizer_loop() {


### PR DESCRIPTION
I added the following values to get_status of linear_mixer.

* ``linear_mixer.is_obsolete``
* ``linear_mixer.is_running``

Next, we should add these to push_mixer.