### PR TITLE
fix cpplint in plugins

### DIFF
--- a/plugin/src/fv_converter/mecab_splitter.cpp
+++ b/plugin/src/fv_converter/mecab_splitter.cpp
@@ -56,7 +56,8 @@ void mecab_splitter::split(
     // cannot create tagger
     return;
   }
-  jubatus::util::lang::scoped_ptr<MeCab::Lattice> lattice(model_->createLattice());
+  jubatus::util::lang::scoped_ptr<MeCab::Lattice> lattice(
+      model_->createLattice());
   if (!lattice) {
     // cannot create lattice
     return;
@@ -99,5 +100,4 @@ jubatus::plugin::fv_converter::mecab_splitter* create(
 std::string version() {
   return JUBATUS_VERSION;
 }
-
-}
+}  // extern "C"

--- a/plugin/src/fv_converter/mecab_splitter_test.cpp
+++ b/plugin/src/fv_converter/mecab_splitter_test.cpp
@@ -102,10 +102,13 @@ void run(mecab_splitter* m) {
 TEST(mecab_spltter, multi_thread) {
   // run mecab_splitter in two threads
   mecab_splitter m;
-  std::vector<jubatus::util::lang::shared_ptr<jubatus::util::concurrent::thread> > ts;
+  std::vector<
+      jubatus::util::lang::shared_ptr<jubatus::util::concurrent::thread> > ts;
   for (int i = 0; i < 100; ++i) {
-    ts.push_back(jubatus::util::lang::shared_ptr<jubatus::util::concurrent::thread>(
-        new jubatus::util::concurrent::thread(jubatus::util::lang::bind(&run , &m))));
+    ts.push_back(
+        jubatus::util::lang::shared_ptr<jubatus::util::concurrent::thread>(
+            new jubatus::util::concurrent::thread(
+                jubatus::util::lang::bind(&run , &m))));
     ts[i]->start();
   }
   for (int i = 0; i < 100; ++i) {

--- a/plugin/src/fv_converter/ux_splitter.cpp
+++ b/plugin/src/fv_converter/ux_splitter.cpp
@@ -109,5 +109,4 @@ jubatus::plugin::fv_converter::ux_splitter* create(
 std::string version() {
   return JUBATUS_VERSION;
 }
-
-}
+}  // extern "C"


### PR DESCRIPTION
Prior to https://github.com/jubatus/jubatus/pull/1025, `plugin` directory was not checked against cpplint.
This fixes cpplint violations in plugins.