### PR TITLE
Fix C++ client test conditions (fix #1019)

### DIFF
--- a/client_test/.gitignore
+++ b/client_test/.gitignore
@@ -1,0 +1,1 @@
+envdef.py

--- a/client_test/README.md
+++ b/client_test/README.md
@@ -1,20 +1,17 @@
 C++ client test
-============
+===================
 
-test_gtest.py is a C++ Jubatus client test(gtest) runner for jubatest.
+test\_gtest.py is a C++ Jubatus client test(gtest) runner for jubatest.
 In envdef.py, specify jubatest.constants as a key and set path to value.
+See envdef.sample.py for the example.
 
-``` envdef.py
-path_to_build_dir = '/path/to/cpp/build'
-env.param('CPP_GTEST', {
-    ANOMALY: path_to_build_dir + '/anomaly_test',
-    CLASSIFIER : path_to_build_dir + '/classifier_test',
-    CLUSTERING: path_to_build_dir + '/clustering_test',
-    GRAPH: path_to_build_dir + '/graph_test',
-    RECOMMENDER: path_to_build_dir + '/recommender_test',
-    REGRESSION: path_to_build_dir + '/regression_test',
-    NEAREST_NEIGHBOR: path_to_build_dir + '/nearest_neighbor_test',
-    STAT: path_to_build_dir + '/stat_test',
-})
+To run the tests:
+
 ```
+$ ./waf configure
 
+$ ./waf build --checkall
+  (note: you can ignore the test errors here)
+
+$ jubatest --config envdef.py --testcase . --pattern test_gtest.py
+```

--- a/client_test/clustering_test.cpp
+++ b/client_test/clustering_test.cpp
@@ -24,6 +24,17 @@ using jubatus::client::common::datum;
 using jubatus::clustering::client::clustering;
 using jubatus::clustering::weighted_datum;
 
+void push_random_data(clustering& cli) {
+  for (int i = 0; i < 1000; ++i) {
+    datum d;
+    d.add_number("neky1", i);
+    d.add_number("neky2", -i);
+    vector<datum> v;
+    v.push_back(d);
+    cli.push(v);
+  }
+}
+
 TEST(clustering_test, get_config) {
   clustering cli(host(), port(), cluster_name(), timeout());
   ASSERT_NE("", cli.get_config());
@@ -63,27 +74,32 @@ TEST(clustering_test, push) {
 
 TEST(clustering_test, get_revision) {
   clustering cli(host(), port(), cluster_name(), timeout());
+  push_random_data(cli);
   cli.get_revision();
 }
 
 TEST(clustering_test, get_core_members) {
   clustering cli(host(), port(), cluster_name(), timeout());
+  push_random_data(cli);
   vector<vector<weighted_datum> > result = cli.get_core_members();
 }
 
 TEST(clustering_test, get_k_center) {
   clustering cli(host(), port(), cluster_name(), timeout());
+  push_random_data(cli);
   vector<datum> result = cli.get_k_center();
 }
 
 TEST(clustering_test, get_nearest_center) {
   clustering cli(host(), port(), cluster_name(), timeout());
+  push_random_data(cli);
   datum d;
   cli.get_nearest_center(d);
 }
 
 TEST(clustering_test, get_nearest_members) {
   clustering cli(host(), port(), cluster_name(), timeout());
+  push_random_data(cli);
   datum d;
   vector<weighted_datum> result = cli.get_nearest_members(d);
 }

--- a/client_test/envdef.sample.py
+++ b/client_test/envdef.sample.py
@@ -1,0 +1,38 @@
+# ----------------------------- #
+#  Test Environment Definition  #
+# ----------------------------- #
+
+###
+### Jubatus Configuration
+###
+env.prefix('/opt/jubatus')
+
+###
+### Test Node Configuration
+###
+env.node('127.0.0.1', range(19199,19299))
+
+###
+### ZooKeeper Configuration
+###
+env.zookeeper('127.0.0.1', 2181)
+
+###
+### Miscellaneous Node Configuration
+###
+env.workdir('/tmp')
+env.cluster_prefix('jubatus_client_test')
+
+###
+### Test Parameters
+path_to_build_dir = './build'
+env.param('CPP_GTEST', {
+    ANOMALY:            path_to_build_dir + '/anomaly_test',
+    CLASSIFIER :        path_to_build_dir + '/classifier_test',
+    CLUSTERING:         path_to_build_dir + '/clustering_test',
+    GRAPH:              path_to_build_dir + '/graph_test',
+    RECOMMENDER:        path_to_build_dir + '/recommender_test',
+    REGRESSION:         path_to_build_dir + '/regression_test',
+    NEAREST_NEIGHBOR:   path_to_build_dir + '/nearest_neighbor_test',
+    STAT:               path_to_build_dir + '/stat_test',
+})

--- a/client_test/test_gtest.py
+++ b/client_test/test_gtest.py
@@ -77,6 +77,7 @@ class ClientStandaloneTest(JubaTestCase, ClientGoogleTestBase):
     def tearDown(self):
         self.server1.stop()
 
+"""
 class ClientDistributedTest(JubaTestCase, ClientGoogleTestBase):
     def lazySetUp(self, service):
         self.node0 = self.env.get_node(0)
@@ -94,3 +95,4 @@ class ClientDistributedTest(JubaTestCase, ClientGoogleTestBase):
     def tearDown(self):
         for server in [self.keeper1, self.server1, self.server2]:
             server.stop()
+"""

--- a/client_test/test_gtest.py
+++ b/client_test/test_gtest.py
@@ -58,7 +58,10 @@ class ClientGoogleTestBase():
         args = [ test_program, '--gtest_filter=%s' % test ]
         env = { 'JUBATUS_HOST': self.client_node.get_host(),
                 'JUBATUS_PORT': str(self.target.get_host_port()[1]),
-                'JUBATUS_CLUSTER_NAME': self.name }
+                'JUBATUS_CLUSTER_NAME': self.name,
+                'JUBATUS_TIMEOUT': str(5),
+                'JUBATUS_SERVERS_COUNT': str(self.servers_count()),
+              }
         env.update(os.environ)
         proc = LocalSubprocess(args, env)
         proc.start()
@@ -67,6 +70,9 @@ class ClientGoogleTestBase():
         self.assertEqual(0, returncode, proc.stdout)
 
 class ClientStandaloneTest(JubaTestCase, ClientGoogleTestBase):
+    def servers_count(self):
+        return 1
+
     def lazySetUp(self, service):
         self.server1 = self.env.server_standalone(self.env.get_node(0), service, default_config(service))
         self.target = self.server1
@@ -79,6 +85,9 @@ class ClientStandaloneTest(JubaTestCase, ClientGoogleTestBase):
 
 """
 class ClientDistributedTest(JubaTestCase, ClientGoogleTestBase):
+    def servers_count(self):
+        return 2
+
     def lazySetUp(self, service):
         self.node0 = self.env.get_node(0)
         self.cluster = self.env.cluster(service, default_config(service))

--- a/client_test/util.hpp
+++ b/client_test/util.hpp
@@ -20,31 +20,42 @@
 #include <stdexcept>
 
 namespace {
+
+std::string get_or_die(const char* key) {
+  const char* str = std::getenv(key);
+  if (!str) {
+    throw std::runtime_error(std::string(key) + " is unset");
+  }
+  return str;
+}
+
 std::string host() {
-  return std::getenv("JUBATUS_HOST");
+  return get_or_die("JUBATUS_HOST");
 }
 
 unsigned int port() {
-  char* str = std::getenv("JUBATUS_PORT");
-  if (!str) {
-    throw std::runtime_error("JUBATUS_PORT is unset");
-  }
-  return std::strtoul(str, NULL, 0);
+  const char* v = get_or_die("JUBATUS_PORT").c_str();
+  return std::strtoul(v, NULL, 0);
 }
 
 std::string cluster_name() {
-  return std::getenv("JUBATUS_CLUSTER_NAME");
+  return get_or_die("JUBATUS_CLUSTER_NAME");
 }
 
 unsigned int timeout() {
-  char* str = std::getenv("TIMEOUT");
-  if (!str) {
-    return 5;
-  }
-  return std::strtoul(str, NULL, 0);
+  return std::strtoul(get_or_die("JUBATUS_TIMEOUT").c_str(), NULL, 0);
+}
+
+unsigned int servers_count() {
+  return std::strtoul(get_or_die("JUBATUS_SERVERS_COUNT").c_str(), NULL, 0);
+}
+
+bool is_standalone() {
+  return cluster_name().length() == 0;
 }
 
 bool has_key(std::map<std::string, std::string>& map, const std::string key) {
   return map.count(key);
 }
-}
+
+}  // namespace


### PR DESCRIPTION
Fix #1019.

* Fix clustering test conditions so that clustering batch runs.
* Remove distributed mode test, as these tests are not intended for integration tests.  Instead, we should write integration tests in [jubatest-cases](https://github.com/kmaehashi/jubatest-cases).
* Add envdef.sample.py along with updated README to easily run tests.
* Improve environment variable handling for better output.