### PR TITLE
Add aggregate-type "add" to jenerator

### DIFF
--- a/tools/jenerator/src/cpp.ml
+++ b/tools/jenerator/src/cpp.ml
@@ -431,6 +431,8 @@ let gen_aggregator names ret_type aggregator =
     gen_template names true "jubatus::server::framework::concat" [t]
   | Map (k, v), Merge ->
     gen_template names true "jubatus::server::framework::merge" [k; v]
+  | Int _, Add | Float _, Add ->
+    gen_template names true "jubatus::server::framework::add" [ret_type]
   | _, Pass ->
     gen_template names true "jubatus::server::framework::pass" [ret_type]
   | _, _ ->

--- a/tools/jenerator/src/syntax.ml
+++ b/tools/jenerator/src/syntax.ml
@@ -42,7 +42,7 @@ type routing_type = | Random | Cht of int | Broadcast | Internal [@@deriving sho
 
 type reqtype = | Update | Analysis | Nolock [@@deriving show];;
 
-type aggtype = | All_and | All_or | Concat | Merge | Ignore | Pass [@@deriving show];;
+type aggtype = | All_and | All_or | Concat | Merge | Add | Ignore | Pass [@@deriving show];;
 
 type decorator_type =
   | Routing of routing_type
@@ -122,6 +122,7 @@ let make_decorator = function
   | "#@all_or"    -> Aggtype(All_or)
   | "#@concat"    -> Aggtype(Concat)
   | "#@merge"     -> Aggtype(Merge)
+  | "#@add"       -> Aggtype(Add)
   | "#@ignore"    -> Aggtype(Ignore)
   | "#@pass"      -> Aggtype(Pass)
   | other ->
@@ -147,6 +148,7 @@ let aggtype_to_string = function
   | All_or  -> "all_or"
   | Concat  -> "concat"
   | Merge   -> "merge"
+  | Add     -> "add"
   | Ignore  -> "ignore" (* or raise sth? *)
   | Pass    -> "pass"
 ;;

--- a/tools/jenerator/test/sample.idl
+++ b/tools/jenerator/test/sample.idl
@@ -10,4 +10,10 @@ service sample {
 
   #@random #@analysis #@merge
   list<string> random_analysis_merge(0: string name)
+
+  #@broadcast #@analysis #@add
+  float broadcast_analysis_add(0: string name)
+
+  #@cht #@analysis #@add
+  int cht_analysis_add(0: string name)
 }


### PR DESCRIPTION
Fixes #1022

> I believe add is unnecessary in aggregators.hpp.

On second thought,  I added ``add`` to ``jenerator``.
Because, we might use ``add`` someday.