### PR TITLE
Avoid clustering identifier conflict

### DIFF
--- a/jubatus/server/server/clustering_serv.cpp
+++ b/jubatus/server/server/clustering_serv.cpp
@@ -85,8 +85,7 @@ void clustering_serv::set_config(const std::string& config) {
     param = *conf.parameter;
   }
 
-  const std::string name =
-      argv().eth + lexical_cast<std::string>(argv().port);
+  const std::string name = get_server_identifier(argv());
   core::clustering::clustering_config cluster_conf =
       core::common::jsonconfig::config_cast_check<
           core::clustering::clustering_config>(param);


### PR DESCRIPTION
Currently, identifier of clustering engine is generated in format of ``IP`` + ``PORT``.
This may cause a conflict of ID in the Jubatus cluster, e.g., (IP: ``10.0.0.11``, Port: ``9199``) and (IP: ``10.0.0.1``, Port: ``19199``) both generate ID ``10.0.0.119199``.
Confliction of ID cause MIX to work improperly.

This patch fixes the problem by inserting ``_`` between IP and Port.

This is slightly related to https://github.com/jubatus/jubatus_core/issues/70.