### PR TITLE
fix oniguruma source URL (fix #1045)

### DIFF
--- a/tools/packaging/allinone/jubapkg
+++ b/tools/packaging/allinone/jubapkg
@@ -70,7 +70,7 @@ do_download() {
 	download_url http://github.com/msgpack/msgpack-c/archive/cpp-${MSGPACK_VER}.tar.gz
 
 	# Oniguruma
-	download_url http://www.geocities.jp/kosako3/oniguruma/archive/onig-${ONIG_VER}.tar.gz
+	download_url https://github.com/kkos/oniguruma/releases/download/v${ONIG_VER}/onig-${ONIG_VER}.tar.gz
 
 	# UX
 	download_url https://github.com/hillbig/ux-trie/archive/${UX_VER}.tar.gz "ux-trie-${UX_VER}.tar.gz"

--- a/tools/packaging/rpm/rpmbuild/oniguruma/SPECS/oniguruma.spec.in
+++ b/tools/packaging/rpm/rpmbuild/oniguruma/SPECS/oniguruma.spec.in
@@ -7,8 +7,8 @@ Release:	%{package_release}%{?dist}
 Summary:    Regular expression library
 Group:		Development/Libraries
 License:	BSD
-URL:		http://www.geocities.jp/kosako3/oniguruma/
-Source0:	http://www.geocities.jp/kosako3/oniguruma/archive/onig-%{version}.tar.gz
+URL:		https://github.com/kkos/oniguruma/
+Source0:	https://github.com/kkos/oniguruma/releases/download/v%{version}/onig-%{version}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %package devel


### PR DESCRIPTION
Fix #1045

As this fix is needed to create build environment of CI server, I intentionally point this PR to master branch.  Need to manually merge this into develop later.