### PR TITLE
nearest_neighbor can be drived with `nolock`

### DIFF
--- a/jubatus/server/server/nearest_neighbor.idl
+++ b/jubatus/server/server/nearest_neighbor.idl
@@ -10,18 +10,18 @@ service nearest_neighbor {
   #@cht(1) #@update #@pass
   bool set_row(0: string id, 1: datum d)
 
-  #@random #@analysis #@pass
+  #@random #@nolock #@pass
   list<id_with_score> neighbor_row_from_id(0: string id, 1: uint size)
 
-  #@random #@analysis #@pass
+  #@random #@nolock #@pass
   list<id_with_score> neighbor_row_from_datum(0: datum query, 1: uint size)
 
-  #@random #@analysis #@pass
+  #@random #@nolock #@pass
   list<id_with_score> similar_row_from_id(0: string id, 1: uint ret_num)
 
-  #@random #@analysis #@pass
+  #@random #@nolock #@pass
   list<id_with_score> similar_row_from_datum(0: datum query, 1: uint ret_num)
 
-  #@random #@analysis #@pass
+  #@random #@nolock #@pass
   list<string> get_all_rows()
 }


### PR DESCRIPTION
With [jubatus_core#188](https://github.com/jubatus/jubatus_core/pull/188), `nearest_neighbor` is now thread safe so that shared lock of these methods can be eliminated.