### PR TITLE
support morpheme n-gram in mecab plugin (fix #1054)

### DIFF
--- a/plugin/src/fv_converter/mecab_splitter.hpp
+++ b/plugin/src/fv_converter/mecab_splitter.hpp
@@ -24,22 +24,26 @@
 #include <mecab.h>
 #include "jubatus/util/lang/scoped_ptr.h"
 
-#include "jubatus/core/fv_converter/word_splitter.hpp"
+#include "jubatus/core/fv_converter/string_feature.hpp"
 
 namespace jubatus {
 namespace plugin {
 namespace fv_converter {
 
-class mecab_splitter : public jubatus::core::fv_converter::word_splitter {
+using core::fv_converter::string_feature_element;
+
+class mecab_splitter : public jubatus::core::fv_converter::string_feature {
  public:
   mecab_splitter();
-  explicit mecab_splitter(const char* arg);
+  explicit mecab_splitter(const char* arg, size_t ngram);
 
-  void split(const std::string& string,
-             std::vector<std::pair<size_t, size_t> >& ret_boundaries) const;
+  void extract(
+      const std::string& string,
+      std::vector<string_feature_element>& result) const;
 
  private:
   jubatus::util::lang::scoped_ptr<MeCab::Model> model_;
+  size_t ngram_;
 };
 
 }  // namespace fv_converter


### PR DESCRIPTION
This PR implements feature proposed in #1054.

I added `"ngram"` configuration option to the MeCab plugin.  Example config file is as follows:

```json
{
  "converter" : {
    "string_filter_types" : {},
    "string_filter_rules" : [],
    "num_filter_types" : {},
    "num_filter_rules" : [],
    "string_types" : {
      "bigram": {"method": "ngram", "char_num": "2"},
      "mecab": {
          "method": "dynamic",
          "path": "libmecab_splitter.so",
          "function": "create",
          "ngram": "2"
      }
    },
    "string_rules" : [
      { "key" : "bigram", "type" : "bigram", "sample_weight" : "bin", "global_weight" : "bin" },
      { "key" : "mecab", "type" : "mecab", "sample_weight" : "bin", "global_weight" : "bin" }
    ],
    "num_types" : {},
    "num_rules" : []
  },
  "method" : "perceptron"
}
```

When `1 < ngram` is specified, morpheme n-gram features are generated.
For example, 2-gram for `本日は晴天なり` will be `{"本日,は": 1.0, "は,晴天": 1.0, "晴天,なり": 1.0}` so it is expected to extract the context of the sentence.

I use `,` character as a separator of two morphemes because we can assume that morphemes do not contain `,`, as MeCab dictionaries are represented in plain CSV as documented in  https://mecab.googlecode.com/svn/trunk/mecab/doc/dic.html