### PR TITLE
Fixes "jubactl -c save" subcommand which is not working

### DIFF
--- a/jubatus/server/cmd/jubactl.cpp
+++ b/jubatus/server/cmd/jubactl.cpp
@@ -273,7 +273,11 @@ void send2server(
         << *it << "..." << std::flush;
 
     try {
-      c.call(cmd, name, id).get<bool>();
+      if (cmd == "save") {
+        c.call(cmd, name, id).get<std::map<string, string> >();
+      } else {
+        c.call(cmd, name, id).get<bool>();
+      }
       cout << "ok." << endl;
     } catch (msgpack::rpc::rpc_error& e) {
       cout << "failed." << endl;


### PR DESCRIPTION
`jubactl -c save` subcommand aborts with `msgpack::type_error` constantly. Example:


    $ jubactl -c save --server jubarecommender --type recommender --name similarticle --zookeeper zk1:2181 --thread 4 --datadir /var/lib/jubatus/
    2016-03-15 23:34:54,753 2442 INFO  [zk.cpp:644] got ZooKeeper event: type SESSION_EVENT(-1), state CONNECTED_STATE(3)
    2016-03-15 23:34:54,753 2442 INFO  [zk.cpp:655] ZooKeeper session established: connected to 10.140.0.4:2181, negotiated timeout 10000 ms
    sending save / similarticle to 10.140.0.3_9199...terminate called after throwing an instance of 'msgpack::type_error'
      what():  std::bad_cast
    Aborted (core dumped)

The cause of the error is that jubactl wrongly expects a bool result from `save` RPC call, although it returns a map<string, string> actually.

This pull request fixes the bug.
