### PR TITLE
Add log message when fowarded request is timed out

### DIFF
--- a/jubatus/server/framework/proxy.hpp
+++ b/jubatus/server/framework/proxy.hpp
@@ -421,6 +421,9 @@ class proxy
             // cancelled sessions (e.g., connections) cannot be reused,
             // so remove them from the session pool.
             at_loop_->pool().remove_session(sessions_[i]);
+
+            LOG(WARNING) << "request timeout occurred: " << hosts_[i].first
+                         << ":" << hosts_[i].second;
           }
         }
 


### PR DESCRIPTION
This patch fixes #1048 

```
2016-03-16 15:44:33,808 4489 WARN  [proxy.hpp:425] request timeout occurred: xxx.xx.xxx.xx:9111
```