### PR TITLE
use config in model file (fix #1081)

### DIFF
--- a/jubatus/server/framework/save_load.cpp
+++ b/jubatus/server/framework/save_load.cpp
@@ -157,8 +157,11 @@ void save_server(FILE* fp,
   }
 }
 
-void load_server(std::istream& is,
-    server_base& server, const std::string& id) {
+void load_server(
+    std::istream& is,
+    server_base& server,
+    const std::string& id,
+    bool overwrite_config) {
   init_versions();
 
   char header_buf[48];
@@ -222,6 +225,11 @@ void load_server(std::istream& is,
         core::common::exception::runtime_error(
           "system data is broken"));
   }
+
+  if (overwrite_config) {
+    server.set_config(system_data_actual.config);
+  }
+
   system_data_container system_data_expected(server, id);
   if (system_data_actual.version != system_data_expected.version) {
     throw JUBATUS_EXCEPTION(
@@ -237,6 +245,7 @@ void load_server(std::istream& is,
           "server type mismatched: " + system_data_actual.type +
           ", expected " + system_data_expected.type));
   }
+
   if (!compare_config(
       system_data_actual.config, system_data_expected.config)) {
     throw JUBATUS_EXCEPTION(

--- a/jubatus/server/framework/save_load.hpp
+++ b/jubatus/server/framework/save_load.hpp
@@ -27,10 +27,15 @@ namespace jubatus {
 namespace server {
 namespace framework {
 
-void save_server(FILE* fp,
-    const server_base& server, const std::string& id);
-void load_server(std::istream& is,
-    server_base& server, const std::string& id);
+void save_server(
+    FILE* fp,
+    const server_base& server,
+    const std::string& id);
+void load_server(
+    std::istream& is,
+    server_base& server,
+    const std::string& id,
+    bool overwrite_config);
 
 }  // namespace framework
 }  // namespace server

--- a/jubatus/server/framework/server_helper.hpp
+++ b/jubatus/server/framework/server_helper.hpp
@@ -114,7 +114,7 @@ class server_helper {
     } catch (const std::runtime_error& e) {
       throw;
     }
- }
+  }
 
   std::map<std::string, std::string> get_loads() const {
     std::map<std::string, std::string> result;

--- a/jubatus/server/framework/server_util.cpp
+++ b/jubatus/server/framework/server_util.cpp
@@ -264,12 +264,15 @@ server_argv::server_argv(int args, char** argv, const std::string& type)
   }
 
   if (is_standalone()) {
-    if (configpath.empty()) {
-      std::cerr << "can't start standalone mode without configpath specified"
-          << std::endl;
+    if (configpath.empty() && modelpath.empty()) {
+      std::cerr << "config path or model file must be specified "
+                << "for standalone mode" << std::endl;
       std::cerr << p.usage() << std::endl;
       exit(1);
     }
+  }
+
+  if (!configpath.empty()) {
     configpath = common::real_path(configpath);
   }
 


### PR DESCRIPTION
Fixes #1081.

In standalone, if a model file is specifed on startup, use the configuration from the model file.
When both a model file and a config file is specified, the config file is ignored (and INFO log to notify that to user is printed).

This fix does not affect distributed mode.
In distributed mode, you cannot specify a model file on startup.