### PR TITLE
Improve get_labels

### DIFF
--- a/jubatus/client/anomaly_client.hpp
+++ b/jubatus/client/anomaly_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_ANOMALY_CLIENT_HPP_

--- a/jubatus/client/anomaly_types.hpp
+++ b/jubatus/client/anomaly_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_ANOMALY_TYPES_HPP_

--- a/jubatus/client/bandit_client.hpp
+++ b/jubatus/client/bandit_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_BANDIT_CLIENT_HPP_

--- a/jubatus/client/bandit_types.hpp
+++ b/jubatus/client/bandit_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_BANDIT_TYPES_HPP_

--- a/jubatus/client/burst_client.hpp
+++ b/jubatus/client/burst_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_BURST_CLIENT_HPP_

--- a/jubatus/client/burst_types.hpp
+++ b/jubatus/client/burst_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_BURST_TYPES_HPP_

--- a/jubatus/client/classifier_client.hpp
+++ b/jubatus/client/classifier_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_CLASSIFIER_CLIENT_HPP_
@@ -33,9 +33,9 @@ class classifier : public jubatus::client::common::client {
     return f.get<std::vector<std::vector<estimate_result> > >();
   }
 
-  std::vector<std::string> get_labels() {
+  std::map<std::string, uint64_t> get_labels() {
     msgpack::rpc::future f = c_.call("get_labels", name_);
-    return f.get<std::vector<std::string> >();
+    return f.get<std::map<std::string, uint64_t> >();
   }
 
   bool set_label(const std::string& new_label) {

--- a/jubatus/client/classifier_types.hpp
+++ b/jubatus/client/classifier_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_CLASSIFIER_TYPES_HPP_

--- a/jubatus/client/clustering_client.hpp
+++ b/jubatus/client/clustering_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_CLUSTERING_CLIENT_HPP_

--- a/jubatus/client/clustering_types.hpp
+++ b/jubatus/client/clustering_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_CLUSTERING_TYPES_HPP_

--- a/jubatus/client/graph_client.hpp
+++ b/jubatus/client/graph_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_GRAPH_CLIENT_HPP_

--- a/jubatus/client/graph_types.hpp
+++ b/jubatus/client/graph_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_GRAPH_TYPES_HPP_

--- a/jubatus/client/nearest_neighbor_client.hpp
+++ b/jubatus/client/nearest_neighbor_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_NEAREST_NEIGHBOR_CLIENT_HPP_

--- a/jubatus/client/nearest_neighbor_types.hpp
+++ b/jubatus/client/nearest_neighbor_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_NEAREST_NEIGHBOR_TYPES_HPP_

--- a/jubatus/client/recommender_client.hpp
+++ b/jubatus/client/recommender_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_RECOMMENDER_CLIENT_HPP_

--- a/jubatus/client/recommender_types.hpp
+++ b/jubatus/client/recommender_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_RECOMMENDER_TYPES_HPP_

--- a/jubatus/client/regression_client.hpp
+++ b/jubatus/client/regression_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_REGRESSION_CLIENT_HPP_

--- a/jubatus/client/regression_types.hpp
+++ b/jubatus/client/regression_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_REGRESSION_TYPES_HPP_

--- a/jubatus/client/stat_client.hpp
+++ b/jubatus/client/stat_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_STAT_CLIENT_HPP_

--- a/jubatus/client/stat_types.hpp
+++ b/jubatus/client/stat_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_STAT_TYPES_HPP_

--- a/jubatus/server/server/anomaly_client.hpp
+++ b/jubatus/server/server/anomaly_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_CLIENT_HPP_

--- a/jubatus/server/server/anomaly_impl.cpp
+++ b/jubatus/server/server/anomaly_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/anomaly_proxy.cpp
+++ b/jubatus/server/server/anomaly_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/anomaly_types.hpp
+++ b/jubatus/server/server/anomaly_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_TYPES_HPP_

--- a/jubatus/server/server/bandit_impl.cpp
+++ b/jubatus/server/server/bandit_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/bandit_proxy.cpp
+++ b/jubatus/server/server/bandit_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/bandit_types.hpp
+++ b/jubatus/server/server/bandit_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_BANDIT_TYPES_HPP_

--- a/jubatus/server/server/burst_impl.cpp
+++ b/jubatus/server/server/burst_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/burst_proxy.cpp
+++ b/jubatus/server/server/burst_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/burst_types.hpp
+++ b/jubatus/server/server/burst_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_BURST_TYPES_HPP_

--- a/jubatus/server/server/classifier.idl
+++ b/jubatus/server/server/classifier.idl
@@ -59,7 +59,7 @@ service classifier {
   #-
   #-  Get all labels in the model
   #@random #@nolock #@pass
-  list<string> get_labels()
+  map<string, ulong> get_labels()
 
   #- - Parameters:
   #-

--- a/jubatus/server/server/classifier_impl.cpp
+++ b/jubatus/server/server/classifier_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -27,7 +27,7 @@ class classifier_impl : public jubatus::server::common::mprpc::rpc_server {
         std::vector<jubatus::core::fv_converter::datum>)>("classify",
         jubatus::util::lang::bind(&classifier_impl::classify, this,
         jubatus::util::lang::_2));
-    rpc_server::add<std::vector<std::string>(std::string)>("get_labels",
+    rpc_server::add<std::map<std::string, uint64_t>(std::string)>("get_labels",
         jubatus::util::lang::bind(&classifier_impl::get_labels, this));
     rpc_server::add<bool(std::string, std::string)>("set_label",
         jubatus::util::lang::bind(&classifier_impl::set_label, this,
@@ -62,7 +62,7 @@ class classifier_impl : public jubatus::server::common::mprpc::rpc_server {
     return get_p()->classify(data);
   }
 
-  std::vector<std::string> get_labels() {
+  std::map<std::string, uint64_t> get_labels() {
     NOLOCK_(p_);
     return get_p()->get_labels();
   }

--- a/jubatus/server/server/classifier_proxy.cpp
+++ b/jubatus/server/server/classifier_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -21,7 +21,7 @@ int run_proxy(int argc, char* argv[]) {
     k.register_async_random<int32_t, std::vector<labeled_datum> >("train");
     k.register_async_random<std::vector<std::vector<estimate_result> >,
         std::vector<jubatus::core::fv_converter::datum> >("classify");
-    k.register_async_random<std::vector<std::string> >("get_labels");
+    k.register_async_random<std::map<std::string, uint64_t> >("get_labels");
     k.register_async_broadcast<bool, std::string>("set_label",
         jubatus::util::lang::function<bool(bool, bool)>(
         &jubatus::server::framework::all_and));

--- a/jubatus/server/server/classifier_serv.cpp
+++ b/jubatus/server/server/classifier_serv.cpp
@@ -16,6 +16,7 @@
 
 #include "classifier_serv.hpp"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,7 @@
 #include "jubatus/util/lang/shared_ptr.h"
 
 #include "jubatus/core/classifier/classifier_factory.hpp"
+#include "jubatus/core/classifier/classifier_type.hpp"
 #include "jubatus/core/common/vector_util.hpp"
 #include "jubatus/core/common/jsonconfig.hpp"
 #include "jubatus/core/fv_converter/datum.hpp"
@@ -189,9 +191,15 @@ void classifier_serv::check_set_config() const {
   }
 }
 
-vector<string> classifier_serv::get_labels() const {
+std::map<string, uint64_t> classifier_serv::get_labels() const {
   check_set_config();
-  return classifier_->get_labels();
+  std::map<string, uint64_t> result;
+  core::classifier::labels_t labels = classifier_->get_labels();
+  for (core::classifier::labels_t::const_iterator it = labels.begin();
+       it != labels.end(); ++it) {
+    result.insert(std::make_pair(it->first, it->second));
+  }
+  return result;
 }
 
 bool classifier_serv::set_label(const std::string& label) {

--- a/jubatus/server/server/classifier_serv.hpp
+++ b/jubatus/server/server/classifier_serv.hpp
@@ -17,6 +17,7 @@
 #ifndef JUBATUS_SERVER_SERVER_CLASSIFIER_SERV_HPP_
 #define JUBATUS_SERVER_SERVER_CLASSIFIER_SERV_HPP_
 
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -53,7 +54,7 @@ class classifier_serv : public framework::server_base {
   std::vector<std::vector<estimate_result> > classify(
       const std::vector<jubatus::core::fv_converter::datum>& data) const;
 
-  std::vector<std::string> get_labels() const;
+  std::map<std::string, uint64_t> get_labels() const;
   bool set_label(const std::string& label);
   bool delete_label(const std::string& label);
 

--- a/jubatus/server/server/classifier_types.hpp
+++ b/jubatus/server/server/classifier_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.7.2-49-g5a6436d) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_CLASSIFIER_TYPES_HPP_

--- a/jubatus/server/server/clustering_impl.cpp
+++ b/jubatus/server/server/clustering_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/clustering_proxy.cpp
+++ b/jubatus/server/server/clustering_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/clustering_types.hpp
+++ b/jubatus/server/server/clustering_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from clustering.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_CLUSTERING_TYPES_HPP_

--- a/jubatus/server/server/graph_client.hpp
+++ b/jubatus/server/server/graph_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_GRAPH_CLIENT_HPP_

--- a/jubatus/server/server/graph_impl.cpp
+++ b/jubatus/server/server/graph_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/graph_proxy.cpp
+++ b/jubatus/server/server/graph_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/graph_types.hpp
+++ b/jubatus/server/server/graph_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_GRAPH_TYPES_HPP_

--- a/jubatus/server/server/nearest_neighbor_impl.cpp
+++ b/jubatus/server/server/nearest_neighbor_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/nearest_neighbor_proxy.cpp
+++ b/jubatus/server/server/nearest_neighbor_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/nearest_neighbor_types.hpp
+++ b/jubatus/server/server/nearest_neighbor_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_NEAREST_NEIGHBOR_TYPES_HPP_

--- a/jubatus/server/server/recommender_impl.cpp
+++ b/jubatus/server/server/recommender_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/recommender_proxy.cpp
+++ b/jubatus/server/server/recommender_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/recommender_types.hpp
+++ b/jubatus/server/server/recommender_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_RECOMMENDER_TYPES_HPP_

--- a/jubatus/server/server/regression_impl.cpp
+++ b/jubatus/server/server/regression_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/regression_proxy.cpp
+++ b/jubatus/server/server/regression_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/regression_types.hpp
+++ b/jubatus/server/server/regression_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_REGRESSION_TYPES_HPP_

--- a/jubatus/server/server/stat_impl.cpp
+++ b/jubatus/server/server/stat_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/stat_proxy.cpp
+++ b/jubatus/server/server/stat_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/stat_types.hpp
+++ b/jubatus/server/server/stat_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.1-11-g6aaff17/develop
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_STAT_TYPES_HPP_


### PR DESCRIPTION
This patch is a part of jubatus/jubatus_core#272

I used the wrong type (``int``) in #1106 .
I used the correct type (``ulong``) in this patch.