### PR TITLE
add include guard check to run_cpplit (server)

### DIFF
--- a/tools/codestyle/run_cpplint.sh
+++ b/tools/codestyle/run_cpplint.sh
@@ -16,3 +16,5 @@ find ${@} '(' \
     ')' \
 | xargs "$(dirname ${0})/cpplint/cpplint.py" --filter=-runtime/references,-runtime/rtti 2>&1 \
 | grep -v '^Done processing '
+
+"$(dirname ${0})/check_include_guard.sh" $(find ${@} -name "*.hpp")


### PR DESCRIPTION
Now `./waf cpplint` checks include guard.

Refs https://github.com/jubatus/jubatus_core/pull/293