### PR TITLE
Add missing lock in get_status

### DIFF
--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -344,6 +344,7 @@ void linear_mixer::updated() {
 }
 
 void linear_mixer::get_status(server_base::status_t& status) const {
+  scoped_lock lk(m_);
   status["linear_mixer.count"] =
       jubatus::util::lang::lexical_cast<string>(counter_);
   // since last mix


### PR DESCRIPTION
Fixes #1093 

I changed to be the  same as ``push_mixer``.
https://github.com/jubatus/jubatus/blob/0.9.2/jubatus/server/framework/mixer/push_mixer.cpp#L293