### PR TITLE
Reconsider the exclusive controls in MIX

### DIFF
--- a/jubatus/server/common/unique_lock.hpp
+++ b/jubatus/server/common/unique_lock.hpp
@@ -93,6 +93,14 @@ class basic_unique_lock : jubatus::util::lang::noncopyable {
     l.swap(r);
   }
 
+  void lock() {
+    if (!locked_) {
+      JUBATUS_ASSERT(lp_ != NULL);
+      lock_functions::lock(*lp_);
+      locked_ = true;
+    }
+  }
+
   void unlock() {
     if (locked_) {
       JUBATUS_ASSERT(lp_ != NULL);

--- a/jubatus/server/common/unique_lock_test.cpp
+++ b/jubatus/server/common/unique_lock_test.cpp
@@ -74,20 +74,20 @@ TEST(unique_lock, lock) {
   ASSERT_FALSE(m.locked());
 
   unique_lock lk(m);
-  ASSERT_TRUE(lk.locked());
-  ASSERT_TRUE(m.locked());
+  EXPECT_TRUE(lk.locked());
+  EXPECT_TRUE(m.locked());
 
   lk.lock();
-  ASSERT_TRUE(lk.locked());
-  ASSERT_TRUE(m.locked());
+  EXPECT_TRUE(lk.locked());
+  EXPECT_TRUE(m.locked());
 
   lk.unlock();
   EXPECT_FALSE(lk.locked());
   EXPECT_FALSE(m.locked());
 
   lk.lock();
-  ASSERT_TRUE(lk.locked());
-  ASSERT_TRUE(m.locked());
+  EXPECT_TRUE(lk.locked());
+  EXPECT_TRUE(m.locked());
 }
 
 TEST(unique_lock, unlock) {

--- a/jubatus/server/common/unique_lock_test.cpp
+++ b/jubatus/server/common/unique_lock_test.cpp
@@ -69,6 +69,27 @@ TEST(unique_lock, simple_lock) {
   EXPECT_FALSE(m.locked());
 }
 
+TEST(unique_lock, lock) {
+  lockable_mock m;
+  ASSERT_FALSE(m.locked());
+
+  unique_lock lk(m);
+  ASSERT_TRUE(lk.locked());
+  ASSERT_TRUE(m.locked());
+
+  lk.lock();
+  ASSERT_TRUE(lk.locked());
+  ASSERT_TRUE(m.locked());
+
+  lk.unlock();
+  EXPECT_FALSE(lk.locked());
+  EXPECT_FALSE(m.locked());
+
+  lk.lock();
+  ASSERT_TRUE(lk.locked());
+  ASSERT_TRUE(m.locked());
+}
+
 TEST(unique_lock, unlock) {
   lockable_mock m;
   ASSERT_FALSE(m.locked());

--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -395,6 +395,8 @@ void linear_mixer::stabilizer_loop() {
           // print versions of mixables
           LOG(INFO) << ".... mix done. versions"
                     << version_list(driver_->get_versions());
+
+          lk.lock();
         }
       }
 

--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -381,7 +381,7 @@ void linear_mixer::stabilizer_loop() {
           || (0 < tick_threshold_
               && new_ticktime - ticktime_ > tick_threshold_))
           && (0 < counter_)) {
-        lk.unlock();  // Release the lock during tring to get zk lock.
+        lk.unlock();  // Release the lock during trying to get zk lock.
         if (zklock->try_lock()) {
           LOG(INFO) << "got ZooKeeper lock, starting mix";
 
@@ -400,7 +400,7 @@ void linear_mixer::stabilizer_loop() {
 
       lk.lock();
       if (is_obsolete_) {
-        lk.unlock();  // Release the lock during tring to get zk lock.
+        lk.unlock();  // Release the lock during trying to get zk lock.
         if (zklock->try_lock()) {
           lk.lock();
           if (is_obsolete_) {

--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -368,8 +368,8 @@ void linear_mixer::stabilizer_loop() {
         return;
       }
 
-      // Release the lock and wait for signal or 0.5 secs.
-      // If meet the conditions, acquire the lock again.
+      // Release the lock and wait for ``c_.notify`` or 0.5 secs.
+      // After waiting, acquire the lock again.
       c_.wait(m_, 0.5);
 
       if (!is_running_) {

--- a/jubatus/server/framework/mixer/linear_mixer.cpp
+++ b/jubatus/server/framework/mixer/linear_mixer.cpp
@@ -398,7 +398,6 @@ void linear_mixer::stabilizer_loop() {
         }
       }
 
-      lk.lock();
       if (is_obsolete_) {
         lk.unlock();  // Release the lock during trying to get zk lock.
         if (zklock->try_lock()) {

--- a/jubatus/server/framework/mixer/linear_mixer.hpp
+++ b/jubatus/server/framework/mixer/linear_mixer.hpp
@@ -120,8 +120,17 @@ class linear_mixer : public mixer {
   bool is_obsolete_;
 
   jubatus::util::concurrent::thread t_;
+
+  // This mutex is used to protect status values (`counter_`, `ticktime_`,
+  // `is_running_`, `is_obsolete_`) and to prevent `stabilizer_loop` while
+  // MIX-RPC is being called.
   mutable jubatus::util::concurrent::mutex m_;
+
+  // This mutex is used to protect model.
+  // We should acquire the lock in the order of ``model_mutex_``, ``m_``
+  // as the same order of ``JRLOCK_`` and `` JWLOCK_``.
   jubatus::util::concurrent::rw_mutex& model_mutex_;
+
   jubatus::util::concurrent::condition c_;
 
   core::driver::driver_base* driver_;

--- a/jubatus/server/framework/mixer/push_mixer.cpp
+++ b/jubatus/server/framework/mixer/push_mixer.cpp
@@ -89,7 +89,10 @@ class push_communication_impl : public push_communication {
  private:
   vector<pair<string, int> > servers_;
   jubatus::util::lang::shared_ptr<common::lock_service> zk_;
-  mutable jubatus::util::concurrent::mutex m_;  // saves servers_ and zk_
+
+  // This mutex is used to protect zk operation and `servers_`.
+  mutable jubatus::util::concurrent::mutex m_;
+
   const string type_;
   const string name_;
   const int timeout_sec_;
@@ -298,13 +301,15 @@ void push_mixer::get_status(server_base::status_t& status) const {
 }
 
 void push_mixer::mixer_loop() {
-  while (is_running_) {
+  while (true) {
     try {
       common::unique_lock lk(m_);
       if (!is_running_) {
         return;
       }
 
+      // Release the lock and wait for signal or 0.5 secs.
+      // If meet the conditions, acquire the lock again.
       c_.wait(m_, 0.5);
 
       if (!is_running_) {
@@ -323,6 +328,8 @@ void push_mixer::mixer_loop() {
 
         lk.unlock();
         mix();
+
+        lk.lock();
         DLOG(INFO) << ".... " << mix_count_ << "th mix done.";
       }
     } catch (const core::common::exception::jubatus_exception& e) {
@@ -339,9 +346,14 @@ void push_mixer::mix() {
   size_t servers_size = communication_->update_members();
   if (servers_size == 0 ||
       (servers_size == 1 && communication_->servers_list()[0] == my_id_)) {
+    common::unique_lock lk(m_);
     if (is_obsolete_) {
+      lk.unlock();
+
       LOG(INFO) << "no server exists, skipping mix";
       communication_->register_active_list();
+
+      lk.lock();
       is_obsolete_ = false;
     }
     return;
@@ -394,8 +406,13 @@ void push_mixer::mix() {
       return;
     }
 
+    common::unique_lock lk(m_);
     if (is_obsolete_) {
+      lk.unlock();
+
       communication_->register_active_list();
+
+      lk.lock();
       is_obsolete_ = false;
     }
   }
@@ -404,18 +421,23 @@ void push_mixer::mix() {
   LOG(INFO) << (end - start) << " time elapsed "
             << s_pull << " pulled  "
             << s_push << " pushed";
-  mix_count_++;
+
+  {
+    scoped_lock lk(m_);
+    mix_count_++;
+  }
 }
 
 byte_buffer push_mixer::pull(const msgpack::object& arg_obj) {
+  scoped_rlock lk_read(model_mutex_);
+  scoped_lock lk(m_);  // Prevent `stabilizer_loop` to awake from `wait`.
+
   if (arg_obj.type != msgpack::type::RAW) {
     throw msgpack::rpc::argument_error();
   }
   msgpack::unpacked msg;
   msgpack::unpack(&msg, arg_obj.via.raw.ptr, arg_obj.via.raw.size);
   msgpack::object arg = msg.get();
-
-  scoped_rlock lk_read(model_mutex_);
 
   core::framework::push_mixable* mixable =
     dynamic_cast<core::framework::push_mixable*>(driver_->get_mixable());
@@ -432,6 +454,7 @@ byte_buffer push_mixer::pull(const msgpack::object& arg_obj) {
 
 byte_buffer push_mixer::get_pull_argument(int dummy_arg) {
   scoped_rlock lk_read(model_mutex_);
+  scoped_lock lk(m_);  // Prevent `stabilizer_loop` to awake from `wait`.
 
   core::framework::push_mixable* mixable =
     dynamic_cast<core::framework::push_mixable*>(driver_->get_mixable());
@@ -447,6 +470,11 @@ byte_buffer push_mixer::get_pull_argument(int dummy_arg) {
 }
 
 int push_mixer::push(const msgpack::object& diff_obj) {
+  scoped_wlock lk_write(model_mutex_);
+  // Prevent `stabilizer_loop` to awake from `wait` and protect
+  // status values.
+  scoped_lock lk(m_);
+
   if (diff_obj.type != msgpack::type::RAW) {
     throw msgpack::rpc::argument_error();
   }
@@ -455,7 +483,6 @@ int push_mixer::push(const msgpack::object& diff_obj) {
   msgpack::unpack(&msg, diff_obj.via.raw.ptr, diff_obj.via.raw.size);
   msgpack::object diff = msg.get();
 
-  scoped_wlock lk_write(model_mutex_);
   core::framework::push_mixable* mixable =
     dynamic_cast<core::framework::push_mixable*>(driver_->get_mixable());
 

--- a/jubatus/server/framework/mixer/push_mixer.cpp
+++ b/jubatus/server/framework/mixer/push_mixer.cpp
@@ -308,8 +308,8 @@ void push_mixer::mixer_loop() {
         return;
       }
 
-      // Release the lock and wait for signal or 0.5 secs.
-      // If meet the conditions, acquire the lock again.
+      // Release the lock and wait for ``c_.notify`` or 0.5 secs.
+      // After waiting, acquire the lock again.
       c_.wait(m_, 0.5);
 
       if (!is_running_) {

--- a/jubatus/server/framework/mixer/push_mixer.hpp
+++ b/jubatus/server/framework/mixer/push_mixer.hpp
@@ -126,8 +126,17 @@ class push_mixer : public jubatus::server::framework::mixer::mixer {
   bool is_obsolete_;
 
   jubatus::util::concurrent::thread t_;
+
+  // This mutex is used to protect status values (`counter_`, `mix_count_`,
+  // `ticktime_`, `is_running_`, `is_obsolete_`) and to prevent
+  // `stabilizer_loop` while MIX-RPC is being called.
   mutable jubatus::util::concurrent::mutex m_;
+
+  // This mutex is used to protect model.
+  // We should acquire the lock in the order of ``model_mutex_``, ``m_``
+  // as the same order of ``JRLOCK_`` and `` JWLOCK_``.
   jubatus::util::concurrent::rw_mutex& model_mutex_;
+
   jubatus::util::concurrent::condition c_;
   core::driver::driver_base* driver_;
 


### PR DESCRIPTION
~~Fixes #1092~~

In mixer, two mutexes are implemented. But they are not used correctly.

For example, ``m_`` in ``linear_mixer`` should be used to protect status values (`counter_`, `ticktime_`, `is_running_`, `is_obsolete_`) by read/write operation. But ``is_obsolete`` in ``update_model`` is not protected by ``m_`` in the write operation.
https://github.com/jubatus/jubatus/blob/0.9.3/jubatus/server/framework/mixer/linear_mixer.cpp#L593

I reviewed and fixed the exclusive controls in MIX as two mutexes are used correctly.

In addition, I tested with the following test:
https://github.com/rimms/misc/tree/master/monkey-mix

``liner_mixer`` and ``broadcast_mixer`` passed 3 times test.

~~I'm trying to implement this in``push_mixer`` .~~