### PR TITLE
disable _GLIBCXX_DEBUG when configured with --enable-debug (fix #910)

### DIFF
--- a/wscript
+++ b/wscript
@@ -106,7 +106,13 @@ def configure(conf):
   conf.check_cxx(header_name = 'dlfcn.h')
 
   if Options.options.debug:
-    conf.define('_GLIBCXX_DEBUG', 1)
+    """
+    You can uncomment the following line to enable debug mode (useful to
+    check STL-related bugs).  Note that dependency libraries (log4cxx and
+    jubatus_core) must be recompiled with this option.
+    """
+    # conf.define('_GLIBCXX_DEBUG', 1)
+    pass
   else:
     conf.define('NDEBUG', 1)
     conf.define('JUBATUS_DISABLE_ASSERTIONS', 1)

--- a/wscript
+++ b/wscript
@@ -107,14 +107,20 @@ def configure(conf):
 
   if Options.options.debug:
     """
-    You can uncomment the following line to enable debug mode (useful to
-    check STL-related bugs).  Note that dependency libraries (log4cxx and
+    You can compile "debug-enabled" version of Jubatus by ``./waf configure --enable-debug ...``.
+    In debug-enabled Jubatus, DEBUG-level logs and assertions are enabled.
+
+    In addition, if you want to enable Glibc C++ debugging feature (useful to debug STL-related
+    issues), you can uncomment the following line.  Note that dependency libraries (log4cxx and
     jubatus_core) must be recompiled with this option.
     """
     # conf.define('_GLIBCXX_DEBUG', 1)
     pass
   else:
+    # Disable DEBUG logs and standard assertions
     conf.define('NDEBUG', 1)
+
+    # Disable Jubatus specific assertions
     conf.define('JUBATUS_DISABLE_ASSERTIONS', 1)
 
   if Options.options.enable_zookeeper:


### PR DESCRIPTION
Fix #910