### PR TITLE
Fix handling of Google Drive URLs in packaging tools

### DIFF
--- a/tools/packaging/rpm/package-config
+++ b/tools/packaging/rpm/package-config
@@ -67,6 +67,7 @@ UX_RELEASE="1"
 # ==============================================================================
 MECAB_VERSION="0.996"
 MECAB_RELEASE="1"
+MECAB_URL="https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE"
 
 # ==============================================================================
 # mecab-ipadic
@@ -75,6 +76,7 @@ MECAB_IPADIC_VERSION="2.7.0.20070801"
 MECAB_IPADIC_RELEASE="1"
 MECAB_IPADIC_ARCHIVE="mecab-ipadic-2.7.0-20070801.tar.gz"
 MECAB_IPADIC_ARCHIVE_DIR="mecab-ipadic-2.7.0-20070801"
+MECAB_IPADIC_URL="https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM"
 
 # ==============================================================================
 # ZooKeeper

--- a/tools/packaging/rpm/package-prebuild
+++ b/tools/packaging/rpm/package-prebuild
@@ -94,8 +94,10 @@ prepare_rpmbuild() {
 		ux )
 			;;
 		mecab )
+			wget "${MECAB_URL}" -O "mecab-${MECAB_VERSION}.tar.gz"
 			;;
 		mecab-ipadic )
+			wget "${MECAB_IPADIC_URL}" -O "${MECAB_IPADIC_ARCHIVE}"
 			;;
 		* )
 			echo "Unknown package: "${PACKAGE}""

--- a/tools/packaging/rpm/package-prebuild
+++ b/tools/packaging/rpm/package-prebuild
@@ -133,7 +133,7 @@ prepare_rpmbuild() {
 		MECAB_IPADIC_ARCHIVE_DIR
 
 	# Download Sources & Patches if the URL is provided in SPEC file
-	spectool -g "${SPECFILE}"
+	spectool -v -v -v -g "${SPECFILE}"
 
 	popd
 }

--- a/tools/packaging/rpm/package.sh
+++ b/tools/packaging/rpm/package.sh
@@ -118,7 +118,7 @@ main() {
 
 	# Check if commands required to run this script exist.
 	# Commands not included in coreutils package must be listed here.
-	test_command_exists git tar perl yum rpmbuild spectool || exit 1
+	test_command_exists git tar perl yum rpmbuild spectool sudo wget || exit 1
 
 	# See how we're called.
 	AUTO_INSTALL="no"

--- a/tools/packaging/rpm/package.sh
+++ b/tools/packaging/rpm/package.sh
@@ -62,7 +62,7 @@ _EOF_
 # Test if the given command(s) exists in PATH
 test_command_exists() {
 	for CMD in "$@"; do
-		if ! which "${CMD}" > /dev/null 2>&1; then
+		if ! type "${CMD}" > /dev/null 2>&1; then
 			echo "ERROR: Cannot detect '$CMD' command."
 			echo "Try \`yum provides '*/$CMD'\` to find package."
 			return 1

--- a/tools/packaging/rpm/rpmbuild/mecab-ipadic/SPECS/mecab-ipadic.spec.in
+++ b/tools/packaging/rpm/rpmbuild/mecab-ipadic/SPECS/mecab-ipadic.spec.in
@@ -15,8 +15,7 @@ Group:		Applications/Text
 # License is "mecab-ipadic": http://fedoraproject.org/wiki/Licensing#Good_Licenses
 License:	mecab-ipadic
 URL:		http://taku910.github.io/mecab/
-# Note: Using Google Drive URL from http://taku910.github.io/mecab/#download
-Source0:	https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM#/%{target_archive}
+Source0:	%{target_archive}
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 # mecab-config command (in mecab package) is required to configure mecab-ipadic

--- a/tools/packaging/rpm/rpmbuild/mecab/SPECS/mecab.spec.in
+++ b/tools/packaging/rpm/rpmbuild/mecab/SPECS/mecab.spec.in
@@ -8,8 +8,7 @@ Summary:	Yet Another Part-of-Speech and Morphological Analyzer
 Group:		Applications/Text
 License:	BSD / LGPL 2.1 / GPL 2
 URL:		http://taku910.github.io/mecab/
-# Note: Using Google Drive URL from http://taku910.github.io/mecab/#download
-Source0:	https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE#/%{name}-%{version}.tar.gz
+Source0:	%{name}-%{version}.tar.gz
 Patch0:		mecab-fix-dicdir.patch
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 


### PR DESCRIPTION
On RHEL 6, `spectool`, which is a tool to download sources used to build RPM packages, does not handle Google Drive URLs correctly.  More precisely:

* It cannot well-handle URLs like ``http:// ... /#/source-0.1.tar.gz``.  The hash part is completely ignored.
* It expects HTTP server that distributes tarball to support time stamping (to check if local copy of tarball is still up-to-date or not.) It seems that Google Drive HTTP servers does not support time stamping, causing ``HTTP 503: Service Unavailable`` error response.

This PR workarounds the problem by avoid using ``spectool``.