### PR TITLE
Add a note about ux-trie when build with _GLIBCXX_DEBUG

### DIFF
--- a/wscript
+++ b/wscript
@@ -112,7 +112,7 @@ def configure(conf):
 
     In addition, if you want to enable Glibc C++ debugging feature (useful to debug STL-related
     issues), you can uncomment the following line.  Note that dependency libraries (log4cxx and
-    jubatus_core) must be recompiled with this option.
+    jubatus_core) and optional library (ux-trie) must be recompiled with this option.
     """
     # conf.define('_GLIBCXX_DEBUG', 1)
     pass


### PR DESCRIPTION
Fix #1138 

In addition, I tested jubatus (build with ``_GLIBCXX_DEBUG``) using ``waf --checkall``.