### PR TITLE
support printing non-ASCII characters in logs (fix #1078)

### DIFF
--- a/jubatus/server/cmd/jubaconfig.cpp
+++ b/jubatus/server/cmd/jubaconfig.cpp
@@ -14,6 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#include <locale.h>
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -62,6 +64,9 @@ void get_all_config_paths(
 
 int main(int argc, char** argv)
 try {
+  // Explicitly set the current locale to support Unicode output in logs.
+  ::setlocale(LC_ALL, "");
+
   // Configures the logger.
   // We don't provide logging configuration feature for command line tools;
   // just print logs to standard output.

--- a/jubatus/server/cmd/jubactl.cpp
+++ b/jubatus/server/cmd/jubactl.cpp
@@ -14,6 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#include <locale.h>
+
 #include <string>
 #include <vector>
 #include <iostream>
@@ -55,6 +57,9 @@ void status(const string& type, const string& name, const string& zkhosts);
 
 int main(int argc, char** argv)
 try {
+  // Explicitly set the current locale to support Unicode output in logs.
+  ::setlocale(LC_ALL, "");
+
   // Configures the logger.
   // We don't provide logging configuration feature for command line tools;
   // just print logs to standard output.

--- a/jubatus/server/framework/server_util.cpp
+++ b/jubatus/server/framework/server_util.cpp
@@ -19,6 +19,8 @@
 #include <unistd.h>
 #include <errno.h>
 #include <signal.h>
+#include <locale.h>
+
 #include <iostream>
 #include <iomanip>
 #include <string>
@@ -158,6 +160,9 @@ std::string make_ignored_help(const std::string& help) {
 
 server_argv::server_argv(int args, char** argv, const std::string& type)
     : type(type) {
+  // Explicitly set the current locale to support Unicode output in logs.
+  ::setlocale(LC_ALL, "");
+
   cmdline::parser p;
   p.add<int>("rpc-port", 'p', "port number", false, 9199,
              cmdline::range(1, 65535));
@@ -408,6 +413,9 @@ std::string get_server_identifier(const server_argv& a) {
 
 proxy_argv::proxy_argv(int args, char** argv, const std::string& t)
     : type(t) {
+  // Explicitly set the current locale to support Unicode output in logs.
+  ::setlocale(LC_ALL, "");
+
   cmdline::parser p;
   p.add<int>("rpc-port", 'p', "port number", false, 9199,
              cmdline::range(1, 65535));

--- a/jubatus/server/jubavisor/main.cpp
+++ b/jubatus/server/jubavisor/main.cpp
@@ -14,6 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#include <locale.h>
+
 #include <iostream>
 #include <string>
 
@@ -74,6 +76,9 @@ void configure_logger(const std::string& log_config) {
 }  // namespace
 
 int main(int argc, char* argv[]) try {
+  // Explicitly set the current locale to support Unicode output in logs.
+  ::setlocale(LC_ALL, "");
+
   cmdline::parser p;
   p.add<int>("rpc-port", 'p', "port number", false, 9198,
              cmdline::range(1, 65535));


### PR DESCRIPTION
Fix #1078.  Jubatus logger now use locale declared in the environment variable.

Jubatus processes (servers, proxies and commands) now explicitly set ``LC_ALL`` by the following code:

```
setlocale(LC_ALL, "");
```

... as documented in https://svn.apache.org/repos/asf/logging/site/trunk/docs/log4cxx/faq.html#unicode:

>  Applications should call setlocale(LC_ALL, "") on startup or the C RTL will assume US-ASCII.

c.f. https://linuxjm.osdn.jp/html/LDP_man-pages/man3/setlocale.3.html

```
$ jubaclassifier -f テスト.json
2016-08-18 11:02:50,947 10135 FATAL [server_util.hpp:146] exception in main thread: Dynamic exception type: jubatus::core::common::exception::runtime_error::what: Failed to get realpath
    #0 [jubatus::core::common::exception::error_api_func_*] = realpath
    #0 [jubatus::core::common::exception::error_file_name_*] = テスト.json
    #0 [jubatus::core::common::exception::error_errno_*] = No such file or directory (2)
    #0 [jubatus::core::common::exception::error_at_file_*] = ../jubatus/server/common/filesystem.cpp
    #0 [jubatus::core::common::exception::error_at_line_*] = 67
    #0 [jubatus::core::common::exception::error_at_func_*] = std::string jubatus::server::common::real_path(const string&)

$ jubaclassifier_proxy -z テスト
2016-08-18 11:03:13,451 10145 INFO  [server_util.cpp:533] starting jubaclassifier_proxy 0.9.2 RPC server at 192.168.122.211:9199
    pid                  : 10145
    user                 : jubatus
    timeout              : 10
    zookeeper timeout    : 10
    interconnect timeout : 10
    thread               : 4
    logdir               : 
    log config           : 
    zookeeper            : テスト

$ jubaconfig --debug --cmd write --type classifier --file /opt/jubatus/share/jubatus/example/config/classifier/pa.json --zookeeper localhost:2181 --name "ほげ/ふが/" 
2016-08-18 11:14:59,991 11464 INFO  [zk.cpp:644] got ZooKeeper event: type SESSION_EVENT(-1), state CONNECTED_STATE(3)
2016-08-18 11:14:59,991 11464 INFO  [zk.cpp:655] ZooKeeper session established: connected to 127.0.0.1:2181, negotiated timeout 4000 ms
2016-08-18 11:15:01,031 11462 ERROR [zk.cpp:177] failed to create ZooKeeper node: /jubatus/actors/classifier/ほげ/ふが/: bad arguments (-8)
2016-08-18 11:15:01,031 11462 ERROR [zk.cpp:177] failed to create ZooKeeper node: /jubatus/actors/classifier/ほげ/ふが//config_lock: bad arguments (-8)

$ jubavisor --logdir "ほげ/ふが" --zookeeper localhost:2181 &
2016-08-18 11:18:16,586 11587 INFO  [jubavisor.cpp:167] starting 1 processes on localhost:9198/ほげ/ふが/

$ jubactl --cmd start --server localhost:9198 --name "ほげ/ふが/" --type classifier --zookeeper localhost:2181
2016-08-18 11:16:41,821 11509 INFO  [zk.cpp:644] got ZooKeeper event: type SESSION_EVENT(-1), state CONNECTED_STATE(3)
2016-08-18 11:16:41,821 11509 INFO  [zk.cpp:655] ZooKeeper session established: connected to 127.0.0.1:2181, negotiated timeout 4000 ms
2016-08-18 11:16:42,796 11507 INFO  [jubactl.cpp:230] no server to start foo/ほげ/ふが/
```