### PR TITLE
use new macro to define error tags

### DIFF
--- a/jubatus/server/common/mprpc/exception.hpp
+++ b/jubatus/server/common/mprpc/exception.hpp
@@ -25,9 +25,7 @@ namespace server {
 namespace common {
 namespace mprpc {
 
-typedef jubatus::core::common::exception::error_info<
-    struct error_method_,
-    std::string> error_method;
+DEFINE_ERROR_TAG(error_method, "Method", std::string)
 
 class rpc_no_client
   : public core::common::exception::jubaexception<rpc_no_client> {

--- a/jubatus/server/common/mprpc/rpc_error.hpp
+++ b/jubatus/server/common/mprpc/rpc_error.hpp
@@ -69,9 +69,7 @@ class rpc_error {
   jubatus::core::common::exception::exception_thrower_ptr exception_;
 };
 
-typedef jubatus::core::common::exception::error_info<
-    struct error_multi_rpc_,
-    std::vector<rpc_error> > error_multi_rpc;
+DEFINE_ERROR_TAG(error_multi_rpc, "Multi RPC", std::vector<rpc_error>)
 
 inline std::string to_string(const error_multi_rpc& info) {
   std::ostringstream result;


### PR DESCRIPTION
This PR fixes to use new macro ``DEFINE_ERROR_TAG`` instead of directly specializing ``error_info`` via typedef to define error tags.

Needs to be merged once https://github.com/jubatus/jubatus_core/pull/313 got merged.