### PR TITLE
print debug log by default (fix #947)

### DIFF
--- a/jubatus/server/common/logger/logger.hpp
+++ b/jubatus/server/common/logger/logger.hpp
@@ -48,7 +48,7 @@
 #define LOG_ERROR(level) STREAM_LOGGER(level, false)
 #define LOG_WARN(level)  STREAM_LOGGER(level, false)
 #define LOG_INFO(level)  STREAM_LOGGER(level, false)
-#define LOG_DEBUG(level) DEBUG_ONLY STREAM_LOGGER(level, false)
+#define LOG_DEBUG(level) STREAM_LOGGER(level, false)
 #define LOG_TRACE(level) DEBUG_ONLY STREAM_LOGGER(level, false)
 
 // Deprecated (for glog transition)


### PR DESCRIPTION
Fix #947.  This PR changes the logging system to print ``DEBUG`` level logs by defualt, even without configured with ``--enable-debug``.

For example, when similar_row_from_id RPC of NN is called:

```
2016-08-23 16:56:14,732 9901 DEBUG [nearest_neighbor_serv.cpp:159] similar_row_from_id
```

Notes:

* To turn off the DEBUG level logs you need to specify log configuration file.
* You can grep the jubatus source by ``DLOG`` to see what kind of debug logs are currently available.
* Currently TRACE level logs are unused.