### PR TITLE
Add config validation feature (fix #973)

### DIFF
--- a/jubatus/server/framework/server_util.cpp
+++ b/jubatus/server/framework/server_util.cpp
@@ -210,6 +210,7 @@ server_argv::server_argv(int args, char** argv, const std::string& type)
   p.add<std::string>("model_file", 'm',
                      "model data to load at startup", false, "");
   p.add("daemon", 'D', "launch in daemon mode");
+  p.add("config_test", 'T', "run a configuration file syntax test and exit");
 
   p.add<std::string>("zookeeper", 'z',
                      make_ignored_help("zookeeper location"), false);
@@ -259,6 +260,7 @@ server_argv::server_argv(int args, char** argv, const std::string& type)
   configpath = p.get<std::string>("configpath");
   modelpath = p.get<std::string>("model_file");
   daemon = p.exist("daemon");
+  config_test = p.exist("config_test");
 
   // determine listen-address and IPaddr used as ZK 'node-name'
   // TODO(y-oda-oni-juba): check bind_address is valid format

--- a/jubatus/server/framework/server_util.hpp
+++ b/jubatus/server/framework/server_util.hpp
@@ -49,6 +49,9 @@ class datum_to_fv_converter;
 namespace server {
 namespace framework {
 
+template <class S>
+class server_helper;
+
 struct config_json {
   config_json() {
   }
@@ -87,11 +90,12 @@ struct server_argv {
   int interval_count;
   std::string mixer;
   bool daemon;
+  bool config_test;
 
   MSGPACK_DEFINE(port, bind_address, bind_if, timeout,
       zookeeper_timeout, interconnect_timeout, threadnum,
       program_name, type, z, name, datadir, logdir, log_config, eth,
-      interval_sec, interval_count, mixer, daemon);
+      interval_sec, interval_count, mixer, daemon, config_test);
 
   bool is_standalone() const {
     return (z == "");
@@ -131,10 +135,22 @@ void register_lock_service(
     jubatus::util::lang::shared_ptr<common::lock_service> ls);
 void close_lock_service();
 
-template<class ImplServerClass>
+template<class ImplServerClass, class ServerClass>
 int run_server(int args, char** argv, const std::string& type) {
   try {
     server_argv parsed_argv(args, argv, type);
+    if (parsed_argv.config_test) {
+      try {
+        jubatus::server::framework::server_helper<ServerClass> sh(parsed_argv);
+      } catch (const jubatus::core::common::exception::jubatus_exception& e) {
+        std::cerr << "Configuration error:" << std::endl
+                  << e.diagnostic_information(true);
+        return 1;
+      }
+      std::cerr << "Configuration OK" << std::endl;
+      return 0;
+    }
+
     ImplServerClass impl_server(parsed_argv);
     if (!parsed_argv.is_standalone()) {
       impl_server.get_p()->get_mixer()->register_api(impl_server);

--- a/jubatus/server/server/anomaly_impl.cpp
+++ b/jubatus/server/server/anomaly_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.7.2-50-gbcc1e21) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -123,6 +123,7 @@ class anomaly_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::anomaly_impl>
+    jubatus::server::framework::run_server<jubatus::server::anomaly_impl,
+        jubatus::server::anomaly_serv>
       (argc, argv, "anomaly");
 }

--- a/jubatus/server/server/bandit_impl.cpp
+++ b/jubatus/server/server/bandit_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from bandit.idl(0.7.2-79-g2db27d7) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -122,6 +122,7 @@ class bandit_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::bandit_impl>
+    jubatus::server::framework::run_server<jubatus::server::bandit_impl,
+        jubatus::server::bandit_serv>
       (argc, argv, "bandit");
 }

--- a/jubatus/server/server/burst_impl.cpp
+++ b/jubatus/server/server/burst_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from burst.idl(0.6.4-96-g66ed74d) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -144,6 +144,7 @@ class burst_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::burst_impl>
+    jubatus::server::framework::run_server<jubatus::server::burst_impl,
+        jubatus::server::burst_serv>
       (argc, argv, "burst");
 }

--- a/jubatus/server/server/classifier_impl.cpp
+++ b/jubatus/server/server/classifier_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from classifier.idl(0.8.9-17-gd4c007f) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -115,6 +115,7 @@ class classifier_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::classifier_impl>
+    jubatus::server::framework::run_server<jubatus::server::classifier_impl,
+        jubatus::server::classifier_serv>
       (argc, argv, "classifier");
 }

--- a/jubatus/server/server/clustering_impl.cpp
+++ b/jubatus/server/server/clustering_impl.cpp
@@ -1,5 +1,4 @@
 // This file is auto-generated from clustering.idl(0.9.4-19-gc665909) with jenerator version 0.8.5-6-g5a2c923/feature/refactoring_clustering_api
-// *** DO NOT EDIT ***
 
 #include <map>
 #include <string>
@@ -150,6 +149,7 @@ class clustering_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::clustering_impl>
+    jubatus::server::framework::run_server<jubatus::server::clustering_impl,
+        jubatus::server::clustering_serv>
       (argc, argv, "clustering");
 }

--- a/jubatus/server/server/graph_impl.cpp
+++ b/jubatus/server/server/graph_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from graph.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -225,6 +225,7 @@ class graph_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::graph_impl>
+    jubatus::server::framework::run_server<jubatus::server::graph_impl,
+        jubatus::server::graph_serv>
       (argc, argv, "graph");
 }

--- a/jubatus/server/server/nearest_neighbor_impl.cpp
+++ b/jubatus/server/server/nearest_neighbor_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from nearest_neighbor.idl(0.8.2-20-g8e4dc3b) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -134,6 +134,6 @@ class nearest_neighbor_impl : public jubatus::server::common::mprpc::rpc_server 
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::nearest_neighbor_impl>
+    jubatus::server::framework::run_server<jubatus::server::nearest_neighbor_impl, jubatus::server::nearest_neighbor_serv>
       (argc, argv, "nearest_neighbor");
 }

--- a/jubatus/server/server/recommender_impl.cpp
+++ b/jubatus/server/server/recommender_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from recommender.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -165,6 +165,7 @@ class recommender_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::recommender_impl>
+    jubatus::server::framework::run_server<jubatus::server::recommender_impl,
+        jubatus::server::recommender_serv>
       (argc, argv, "recommender");
 }

--- a/jubatus/server/server/regression_impl.cpp
+++ b/jubatus/server/server/regression_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from regression.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -92,6 +92,7 @@ class regression_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::regression_impl>
+    jubatus::server::framework::run_server<jubatus::server::regression_impl,
+        jubatus::server::regression_serv>
       (argc, argv, "regression");
 }

--- a/jubatus/server/server/stat_impl.cpp
+++ b/jubatus/server/server/stat_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/feature/improve-get_labels-ulong
+// This file is auto-generated from stat.idl(0.6.4-33-gcc8d7ca) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -129,6 +129,7 @@ class stat_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::stat_impl>
+    jubatus::server::framework::run_server<jubatus::server::stat_impl,
+        jubatus::server::stat_serv>
       (argc, argv, "stat");
 }

--- a/jubatus/server/server/weight_impl.cpp
+++ b/jubatus/server/server/weight_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from weight.idl with jenerator version 0.8.5-6-g5a2c923/develop
+// This file is auto-generated from weight.idl(0.9.0-24-gda61383) with jenerator version 0.8.5-6-g5a2c923/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -91,6 +91,7 @@ class weight_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::weight_impl>
+    jubatus::server::framework::run_server<jubatus::server::weight_impl,
+        jubatus::server::weight_serv>
       (argc, argv, "weight");
 }

--- a/tools/jenerator/src/cpp.ml
+++ b/tools/jenerator/src/cpp.ml
@@ -677,7 +677,7 @@ let gen_impl_file conf names source services =
       (0, "int main(int argc, char* argv[]) {");
       (1,   "return");
       (* TODO(unnonouno): does not work when service name is not equal to a source file*)
-      (2,     "jubatus::server::framework::run_server<" ^ namespace_str ^ "::" ^ base ^ "_impl>");
+      (2,     "jubatus::server::framework::run_server<" ^ namespace_str ^ "::" ^ base ^ "_impl, " ^ namespace_str ^ "::" ^ base ^ "_serv>");
       (3,       "(argc, argv, " ^ name_str ^ ");");
       (0, "}")
     ]


### PR DESCRIPTION
Fix #973.

Add ``--config_test, -T`` option to jubatus server.
By using this option, configurations can be tested without running RPC server.
If the config is OK, the server will exit with status 0; otherwise exit with 1.

Valid config:
```
$ jubaclassifier --config_test -f config/classifier/pa.json
2016-08-24 19:00:54,292 12550 INFO  [server_util.cpp:416] starting jubaclassifier 0.9.3 RPC server at 192.168.122.211:9199
    pid                  : 12550
    user                 : jubatus
    mode                 : standalone mode
    timeout              : 10
    thread               : 2
    datadir              : /tmp
    logdir               : 
    log config           : 
    zookeeper            : 
    name                 : 
    interval sec         : 16
    interval count       : 512
    zookeeper timeout    : 10
    interconnect timeout : 10

2016-08-24 19:00:54,292 12550 INFO  [server_util.cpp:165] load config from local file: /home/jubatus/Development/jubatus/config/classifier/pa.json
2016-08-24 19:00:54,293 12550 INFO  [classifier_serv.cpp:116] config loaded: {
  "converter" : {
    "string_filter_types" : {},
    "string_filter_rules" : [],
    "num_filter_types" : {},
    "num_filter_rules" : [],
    "string_types" : {},
    "string_rules" : [
      { "key" : "*", "type" : "str", "sample_weight" : "bin", "global_weight" : "bin" }
    ],
    "num_types" : {},
    "num_rules" : [
      { "key" : "*", "type" : "num" }
    ]
  },
  "method" : "PA"
}

Configuration OK
```

Invalid config:
```
$ jubaclassifier --config_test -f config/stat/stat.json
2016-08-24 19:01:29,731 12560 INFO  [server_util.cpp:416] starting jubaclassifier 0.9.3 RPC server at 192.168.122.211:9199
    pid                  : 12560
    user                 : jubatus
    mode                 : standalone mode
    timeout              : 10
    thread               : 2
    datadir              : /tmp
    logdir               : 
    log config           : 
    zookeeper            : 
    name                 : 
    interval sec         : 16
    interval count       : 512
    zookeeper timeout    : 10
    interconnect timeout : 10

2016-08-24 19:01:29,731 12560 INFO  [server_util.cpp:165] load config from local file: /home/jubatus/Development/jubatus/config/stat/stat.json
Configuration error:
jubatus::core::common::config_exception: invalid configuration
    (#0) Message: "window_size" is not used ()
    (#0) Message: "method" is not found ()
    (#0) Message: "converter" is not found ()
    (#0) Source: ../jubatus/server/server/../../server/framework/server_helper.hpp
    (#0) Line: 100
    (#0) Function: jubatus::server::framework::server_helper<S>::server_helper(const jubatus::server::framework::server_argv&, bool) [with Server = jubatus::server::classifier_serv]
```

Valid config on ZooKeeper:
```
$ jubaclassifier --config_test --zookeeper localhost:2181 -n test
2016-08-24 18:59:44,983 12491 INFO  [server_util.cpp:416] starting jubaclassifier 0.9.3 RPC server at 192.168.122.211:9199
    pid                  : 12491
    user                 : jubatus
    mode                 : multinode mode
    timeout              : 10
    thread               : 2
    datadir              : /tmp
    logdir               :
    log config           :
    zookeeper            : localhost:2181
    name                 : test
    interval sec         : 16
    interval count       : 512
    zookeeper timeout    : 10
    interconnect timeout : 10

2016-08-24 18:59:44,983:12491(0x7f1adb3ea780):ZOO_INFO@log_env@726: Client environment:zookeeper.version=zookeeper C client 3.4.8
2016-08-24 18:59:44,983:12491(0x7f1adb3ea780):ZOO_INFO@log_env@730: Client environment:host.name=juba-devel01
2016-08-24 18:59:44,983:12491(0x7f1adb3ea780):ZOO_INFO@log_env@737: Client environment:os.name=Linux
2016-08-24 18:59:44,983:12491(0x7f1adb3ea780):ZOO_INFO@log_env@738: Client environment:os.arch=3.2.0-23-generic
2016-08-24 18:59:44,983:12491(0x7f1adb3ea780):ZOO_INFO@log_env@739: Client environment:os.version=#36-Ubuntu SMP Tue Apr 10 20:39:51 UTC 2012
2016-08-24 18:59:44,984:12491(0x7f1adb3ea780):ZOO_INFO@log_env@747: Client environment:user.name=jubatus
2016-08-24 18:59:44,984:12491(0x7f1adb3ea780):ZOO_INFO@log_env@755: Client environment:user.home=/home/jubatus
2016-08-24 18:59:44,984:12491(0x7f1adb3ea780):ZOO_INFO@log_env@767: Client environment:user.dir=/home/jubatus/Development/jubatus
2016-08-24 18:59:44,984:12491(0x7f1adb3ea780):ZOO_INFO@zookeeper_init@800: Initiating client connection, host=localhost:2181 sessionTimeout=10000 watcher=0x7f1ada8d79c0 sessionId=0 sessionPasswd=<null> context=0x1eb13c0 flags=0
2016-08-24 18:59:44,984:12491(0x7f1ad5814700):ZOO_INFO@check_events@1728: initiated connection to server [127.0.0.1:2181]
2016-08-24 18:59:45,003:12491(0x7f1ad5814700):ZOO_INFO@check_events@1775: session establishment complete on server [127.0.0.1:2181], sessionId=0x1568d853111001b, negotiated timeout=4000
2016-08-24 18:59:45,003 12494 INFO  [zk.cpp:644] got ZooKeeper event: type SESSION_EVENT(-1), state CONNECTED_STATE(3)
2016-08-24 18:59:45,003 12494 INFO  [zk.cpp:655] ZooKeeper session established: connected to 127.0.0.1:2181, negotiated timeout 4000 ms
2016-08-24 18:59:45,994 12491 DEBUG [zk.cpp:183] create /jubatus
2016-08-24 18:59:46,002 12491 DEBUG [zk.cpp:183] create /jubatus/supervisors
2016-08-24 18:59:46,011 12491 DEBUG [zk.cpp:183] create /jubatus/jubaproxies
2016-08-24 18:59:46,019 12491 DEBUG [zk.cpp:183] create /jubatus/actors
2016-08-24 18:59:46,027 12491 DEBUG [zk.cpp:183] create /jubatus/config
2016-08-24 18:59:46,036 12491 DEBUG [zk.cpp:183] create /jubatus/actors/classifier
2016-08-24 18:59:46,044 12491 DEBUG [zk.cpp:183] create /jubatus/config/classifier
2016-08-24 18:59:46,052 12491 DEBUG [zk.cpp:183] create /jubatus/actors/classifier/test
2016-08-24 18:59:46,061 12491 DEBUG [zk.cpp:183] create /jubatus/actors/classifier/test/config_lock
2016-08-24 18:59:46,061 12491 INFO  [server_helper.cpp:75] joining to the cluster test

2016-08-24 18:59:46,071 12491 INFO  [classifier_serv.cpp:116] config loaded: {
  "converter" : {
    "string_filter_types" : {},
    "string_filter_rules" : [],
    "num_filter_types" : {},
    "num_filter_rules" : [],
    "string_types" : {},
    "string_rules" : [
      { "key" : "*", "type" : "str", "sample_weight" : "bin", "global_weight" : "bin" }
    ],
    "num_types" : {},
    "num_rules" : [
      { "key" : "*", "type" : "num" }
    ]
  },
  "method" : "PA"
}

2016-08-24 18:59:46,077 12491 DEBUG [zk.cpp:243] remove /jubatus/actors/classifier/test/config_lock/rlock_0000000188
2016-08-24 18:59:46,078:12491(0x7f1adb3ea780):ZOO_INFO@zookeeper_close@2526: Closing zookeeper sessionId=0x1568d853111001b to [127.0.0.1:2181]

Configuration OK
```