### PR TITLE
Fix default log level to INFO when --log_config is not specified

### DIFF
--- a/jubatus/server/common/logger/logger.cpp
+++ b/jubatus/server/common/logger/logger.cpp
@@ -107,6 +107,8 @@ void configure() {
       new log4cxx::PatternLayout("%d %X{tid} %-5p [%F:%L] %m%n"));
   log4cxx::AppenderPtr appender(new log4cxx::ConsoleAppender(layout));
   log4cxx::BasicConfigurator::configure(appender);
+  log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger(LOGGER_NAME);
+  logger->setLevel(log4cxx::Level::getInfo());
 }
 
 void configure(const std::string& config_file) {

--- a/log4cxx.xml
+++ b/log4cxx.xml
@@ -19,8 +19,9 @@
 
   <root>
     <priority value="info" />
-    <!-- <appender-ref ref="stdout" /> -->
     <appender-ref ref="file" />
+    <!-- <priority value="debug" /> -->
+    <!-- <appender-ref ref="stdout" /> -->
   </root>
 
 </log4j:configuration>


### PR DESCRIPTION
DLOGs are frequently used: e.g.  https://github.com/jubatus/jubatus/blob/master/jubatus/server/server/classifier_serv.cpp#L142
To improver performance disable DEBUG logs when not explicitly specified.