### PR TITLE
fast-forward global ID generator in graph engine (fix #1149)

### DIFF
--- a/jubatus/server/framework/server_base.hpp
+++ b/jubatus/server/framework/server_base.hpp
@@ -54,8 +54,8 @@ class server_base {
   virtual bool clear();
   virtual std::map<std::string, std::string> save(const std::string& id);
   virtual bool load(const std::string& id);
+  virtual void load_file(const std::string& path);
 
-  void load_file(const std::string& path);
   void event_model_updated();
   void update_saved_status(const std::string& path);
   void update_loaded_status(const std::string& path);

--- a/jubatus/server/server/graph_serv.cpp
+++ b/jubatus/server/server/graph_serv.cpp
@@ -558,5 +558,28 @@ void graph_serv::get_members_(std::vector<std::pair<std::string, int> >& ret) {
 #endif
 }
 
+bool graph_serv::load(const std::string& id) {
+  if (server_base::load(id)) {
+    reset_id_generator();
+    return true;
+  }
+  return false;
+}
+
+void graph_serv::load_file(const std::string& path) {
+  server_base::load_file(path);
+  reset_id_generator();
+}
+
+void graph_serv::reset_id_generator() {
+  if (argv().is_standalone()) {
+    uint64_t counter = graph_->find_max_int_id() + 1;
+    idgen_.reset(
+        new common::global_id_generator_standalone(counter));
+  } else {
+    // TODO(kmaehashi): support ID check for distributed mode
+  }
+}
+
 }  // namespace server
 }  // namespace jubatus

--- a/jubatus/server/server/graph_serv.hpp
+++ b/jubatus/server/server/graph_serv.hpp
@@ -91,6 +91,10 @@ class graph_serv : public framework::server_base {
 
   bool create_edge_here(edge_id_t eid, const edge& ei);
 
+  // overrides to restore global_id_generator when loading model
+  bool load(const std::string& id);
+  void load_file(const std::string& path);
+
  private:
   void check_set_config() const;
 

--- a/jubatus/server/server/graph_serv.hpp
+++ b/jubatus/server/server/graph_serv.hpp
@@ -104,6 +104,7 @@ class graph_serv : public framework::server_base {
       std::vector<std::pair<std::string, int> >& out);
   void get_members_(std::vector<std::pair<std::string, int> >& ret);
 
+  void reset_id_generator();
 
   jubatus::util::lang::shared_ptr<framework::mixer::mixer> mixer_;
   jubatus::util::lang::shared_ptr<core::driver::graph> graph_;


### PR DESCRIPTION
Fix #1149
This must be merged after https://github.com/jubatus/jubatus_core/pull/333