### PR TITLE
update packaging tools to support image feature extraction

### DIFF
--- a/tools/packaging/allinone/README.md
+++ b/tools/packaging/allinone/README.md
@@ -7,7 +7,7 @@ Building Debian Package
 On Ubuntu 12.04 LTS (x86\_64), the following packages are required.
 
 ```
-sudo apt-get install ssh git build-essential ruby1.9.3 pkg-config autoconf libtool devscripts debhelper liblog4cxx10-dev
+sudo apt-get install ssh git build-essential ruby1.9.3 pkg-config autoconf libtool devscripts debhelper liblog4cxx10-dev libopencv-dev
 ```
 
 Now you can build the package as follows:

--- a/tools/packaging/allinone/jubapkg
+++ b/tools/packaging/allinone/jubapkg
@@ -252,7 +252,7 @@ do_build() {
 	# Jubatus
 	cp -rp ${SOURCE_DIR}/jubatus jubatus
 	pushd jubatus
-	LDFLAGS="-L${DEST_DIR}/${PREFIX}/lib" ./waf configure --prefix=${PREFIX} --enable-ux --enable-mecab --enable-zookeeper
+	LDFLAGS="-L${DEST_DIR}/${PREFIX}/lib" ./waf configure --prefix=${PREFIX} --enable-ux --enable-mecab --enable-zookeeper --enable-opencv
 	./waf build
 	./waf install --destdir=${DEST_DIR}
 	mkdir -p "${DOC_DIR}/jubatus"

--- a/tools/packaging/allinone/metadata/debian/control
+++ b/tools/packaging/allinone/metadata/debian/control
@@ -1,7 +1,7 @@
 Source: jubatus
 Priority: extra
 Maintainer: PFN & NTT <jubatus-team@googlegroups.com>
-Build-Depends: debhelper (>= 8.0.0), autotools-dev, pkg-config, python (>= 2.6), liblog4cxx10-dev
+Build-Depends: debhelper (>= 8.0.0), autotools-dev, pkg-config, python (>= 2.6), liblog4cxx10-dev, libopencv-dev
 Standards-Version: 3.9.3
 Section: misc
 Homepage: http://jubat.us/
@@ -9,7 +9,7 @@ Homepage: http://jubat.us/
 Package: jubatus
 Section: misc
 Architecture: any
-Depends: libc6 (>= 2.14), liblog4cxx10, ${misc:Depends}
+Depends: libc6 (>= 2.14), liblog4cxx10, libopencv-features2d2.4 | libopencv-features2d2.3, ${misc:Depends}
 Description: Distributed processing framework and streaming machine learning library
  Jubatus is a distributed processing framework and streaming machine
  learning library.

--- a/tools/packaging/allinone/metadata/jubatus-allinone.spec
+++ b/tools/packaging/allinone/metadata/jubatus-allinone.spec
@@ -7,6 +7,12 @@ Group:		System Environment/Daemons
 License:	LGPL 2.1
 URL:		http://jubat.us/
 
+BuildRequires:  log4cxx-devel = 0.10.0
+BuildRequires:  opencv-devel >= 2.3
+
+Requires:       log4cxx = 0.10.0
+Requires:       opencv >= 2.3
+
 %description
 Jubatus is a distributed processing framework and streaming machine learning library.
 

--- a/tools/packaging/rpm/README.rst
+++ b/tools/packaging/rpm/README.rst
@@ -7,7 +7,7 @@ RPM Packaging
 
   sudo yum groupinstall 'Development Tools'
   sudo yum install git-core ruby rpm-build rpmdevtools spectool createrepo
-  sudo yum install apr-devel apr-util-devel
+  sudo yum install apr-devel apr-util-devel opencv-devel
 
 2. Modify ``package-config`` to specify which version to build. See below for details.
 

--- a/tools/packaging/rpm/package-prebuild
+++ b/tools/packaging/rpm/package-prebuild
@@ -12,6 +12,9 @@ prepare_rpmbuild() {
 
 	case "${PACKAGE}" in
 		jubatus )
+			# SPEC file for jubatus package is defined for each RHEL version.
+			SPECINFILE="${SPECFILE}.el${JUBATUS_RELEASE_VERSION}.in"
+
 			rm -rf jubatus
 			git clone https://github.com/jubatus/jubatus.git jubatus
 			pushd jubatus

--- a/tools/packaging/rpm/rpmbuild/jubatus/SPECS/jubatus.spec.el6.in
+++ b/tools/packaging/rpm/rpmbuild/jubatus/SPECS/jubatus.spec.el6.in
@@ -1,3 +1,10 @@
+###
+### jubatus.spec.el6.in is a SPEC file for RHEL 6.  It is equivalent to
+### jubatus.spec.el7.in (RHEL 7) except that OpenCV support is excluded
+### as OpenCV shipped with RHEL 6 is too old and our plugin doesn't
+### support it.
+###
+
 %define package_version @JUBATUS_VERSION@
 %define package_release @JUBATUS_RELEASE@
 
@@ -33,9 +40,25 @@ Requires:		msgpack = @MSGPACK_VERSION@
 Requires:		log4cxx = @LOG4CXX_VERSION@
 Requires:		zookeeper-client = @ZOOKEEPER_VERSION@
 Requires:		oniguruma >= 5.9
-Requires:		ux = @UX_VERSION@
-Requires:		mecab = @MECAB_VERSION@
-Requires:		mecab-ipadic = @MECAB_IPADIC_VERSION@
+
+%package plugin-ux
+Summary:	UX-trie feature extraction plug-in
+Group:		Development/Libraries
+Requires:	%{name} = %{version}-%{release}
+Requires:	ux = @UX_VERSION@
+
+%package plugin-mecab
+Summary:	MeCab feature extraction plug-in
+Group:		Development/Libraries
+Requires:	%{name} = %{version}-%{release}
+Requires:	mecab = @MECAB_VERSION@
+Requires:	mecab-ipadic = @MECAB_IPADIC_VERSION@
+
+%package client
+Summary:	Jubatus C++ Client
+Group:		Development/Libraries
+Requires:	msgpack-devel = @MSGPACK_VERSION@
+Requires:	jubatus-msgpack-rpc-devel = @JUBATUS_MSGPACK_RPC_VERSION@
 
 %package devel
 Summary:	Headers and libraries to develop engines and plugins for Jubatus Framework
@@ -46,22 +69,24 @@ Requires:	msgpack-devel = @MSGPACK_VERSION@
 Requires:	log4cxx-devel = @LOG4CXX_VERSION@
 Requires:	oniguruma-devel >= 5.9
 
-%package client
-Summary:	Jubatus C++ Client
-Group:		Development/Libraries
-Requires:	msgpack-devel = @MSGPACK_VERSION@
-Requires:	jubatus-msgpack-rpc-devel = @JUBATUS_MSGPACK_RPC_VERSION@
-
 %description
 Jubatus is a distributed processing framework and streaming machine learning library.
 
-%description devel
+%description plugin-ux
 Jubatus is a distributed processing framework and streaming machine learning library.
-This package provides headers and libraries needed to develop new engines or plugins for Jubatus Framework.
+This package provides UX-trie feature extraction plug-in.
+
+%description plugin-mecab
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides MeCab feature extraction (morphological analysis for Japanese text) plug-in.
 
 %description client
 Jubatus is a distributed processing framework and streaming machine learning library.
 This package provides Jubatus C++ client headers.
+
+%description devel
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides headers and libraries needed to develop new engines or plugins for Jubatus Framework.
 
 %prep
 %setup -q -n %{name}
@@ -83,7 +108,6 @@ find %{buildroot}/%{_libdir} -name "lib*.so*" -exec chmod 755 {} \;
 %doc README.rst LICENSE ChangeLog.rst
 %{_bindir}/juba*
 %{_libdir}/libjuba*.so.*
-%{_libdir}/jubatus/plugin
 %{_datarootdir}/jubatus
 %{_mandir}/man*/*
 %{_mandir}/*/man*/*
@@ -95,6 +119,12 @@ find %{buildroot}/%{_libdir} -name "lib*.so*" -exec chmod 755 {} \;
 %{_includedir}/jubatus
 %exclude %{_includedir}/jubatus/client
 %exclude %{_includedir}/jubatus/client.hpp
+
+%files plugin-ux
+%{_libdir}/jubatus/plugin/libux_splitter.so*
+
+%files plugin-mecab
+%{_libdir}/jubatus/plugin/libmecab_splitter.so*
 
 %files client
 %{_libdir}/pkgconfig/jubatus-client.pc

--- a/tools/packaging/rpm/rpmbuild/jubatus/SPECS/jubatus.spec.el7.in
+++ b/tools/packaging/rpm/rpmbuild/jubatus/SPECS/jubatus.spec.el7.in
@@ -1,0 +1,148 @@
+###
+### jubatus.spec.el7.in is a SPEC file for RHEL 7.  Also see the header
+### comment in jubatus.spec.el6.in.
+###
+
+%define package_version @JUBATUS_VERSION@
+%define package_release @JUBATUS_RELEASE@
+
+%define __waf ./waf
+
+Name:		jubatus
+Version:	%{package_version}
+Release:	%{package_release}%{?dist}
+Summary:	Distributed Online Machine Learning Framework
+Vendor:		PFN & NTT
+Group:		System Environment/Daemons
+License:	LGPL 2.1
+URL:		http://jubat.us/
+Source0:	%{name}-%{version}.tar.gz
+BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+BuildRequires:	jubatus-core-devel = @JUBATUS_CORE_VERSION@
+BuildRequires:	jubatus-mpio-devel = @JUBATUS_MPIO_VERSION@
+BuildRequires:	jubatus-msgpack-rpc-devel = @JUBATUS_MSGPACK_RPC_VERSION@
+BuildRequires:	msgpack-devel = @MSGPACK_VERSION@
+BuildRequires:	log4cxx-devel = @LOG4CXX_VERSION@
+BuildRequires:	zookeeper-client-devel = @ZOOKEEPER_VERSION@
+BuildRequires:	oniguruma-devel >= 5.9
+BuildRequires:	ux-devel = @UX_VERSION@
+BuildRequires:	mecab-devel = @MECAB_VERSION@
+BuildRequires:	opencv-devel >= 2.3
+BuildRequires:	pkgconfig
+BuildRequires:	python >= 2.4
+
+Requires:		jubatus-core = @JUBATUS_CORE_VERSION@
+Requires:		jubatus-mpio = @JUBATUS_MPIO_VERSION@
+Requires:		jubatus-msgpack-rpc = @JUBATUS_MSGPACK_RPC_VERSION@
+Requires:		msgpack = @MSGPACK_VERSION@
+Requires:		log4cxx = @LOG4CXX_VERSION@
+Requires:		zookeeper-client = @ZOOKEEPER_VERSION@
+Requires:		oniguruma >= 5.9
+
+%package plugin-ux
+Summary:	UX-trie feature extraction plug-in
+Group:		Development/Libraries
+Requires:	%{name} = %{version}-%{release}
+Requires:	ux = @UX_VERSION@
+
+%package plugin-mecab
+Summary:	MeCab feature extraction plug-in
+Group:		Development/Libraries
+Requires:	%{name} = %{version}-%{release}
+Requires:	mecab = @MECAB_VERSION@
+Requires:	mecab-ipadic = @MECAB_IPADIC_VERSION@
+
+%package plugin-image
+Summary:	Image feature extraction plug-in
+Group:		Development/Libraries
+Requires:	%{name} = %{version}-%{release}
+Requires:	opencv >= 2.3
+
+%package client
+Summary:	Jubatus C++ Client
+Group:		Development/Libraries
+Requires:	msgpack-devel = @MSGPACK_VERSION@
+Requires:	jubatus-msgpack-rpc-devel = @JUBATUS_MSGPACK_RPC_VERSION@
+
+%package devel
+Summary:	Headers and libraries to develop engines and plugins for Jubatus Framework
+Group:		Development/Libraries
+Requires:	%{name} = %{version}-%{release}
+Requires:	jubatus-msgpack-rpc-devel = @JUBATUS_MSGPACK_RPC_VERSION@
+Requires:	msgpack-devel = @MSGPACK_VERSION@
+Requires:	log4cxx-devel = @LOG4CXX_VERSION@
+Requires:	oniguruma-devel >= 5.9
+
+%description
+Jubatus is a distributed processing framework and streaming machine learning library.
+
+%description plugin-ux
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides UX-trie feature extraction plug-in.
+
+%description plugin-mecab
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides MeCab feature extraction (morphological analysis for Japanese text) plug-in.
+
+%description plugin-image
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides OpenCV image feature extraction plug-in.
+
+%description client
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides Jubatus C++ client headers.
+
+%description devel
+Jubatus is a distributed processing framework and streaming machine learning library.
+This package provides headers and libraries needed to develop new engines or plugins for Jubatus Framework.
+
+%prep
+%setup -q -n %{name}
+
+%build
+%{__waf} configure --prefix=%{_prefix} --libdir=%{_libdir} --enable-zookeeper --enable-ux --enable-mecab --enable-opencv
+%{__waf} build
+
+%install
+%{__rm} -rf %{buildroot}
+%{__waf} install --destdir=%{buildroot}
+find %{buildroot}/%{_libdir} -name "lib*.so*" -exec chmod 755 {} \;
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc README.rst LICENSE ChangeLog.rst
+%{_bindir}/juba*
+%{_libdir}/libjuba*.so.*
+%{_datarootdir}/jubatus
+%{_mandir}/man*/*
+%{_mandir}/*/man*/*
+
+%files devel
+%defattr(-,root,root,-)
+%{_libdir}/libjuba*.so
+%{_libdir}/pkgconfig/jubatus.pc
+%{_includedir}/jubatus
+%exclude %{_includedir}/jubatus/client
+%exclude %{_includedir}/jubatus/client.hpp
+
+%files plugin-ux
+%{_libdir}/jubatus/plugin/libux_splitter.so*
+
+%files plugin-mecab
+%{_libdir}/jubatus/plugin/libmecab_splitter.so*
+
+%files plugin-image
+%{_libdir}/jubatus/plugin/libimage_feature.so*
+
+%files client
+%{_libdir}/pkgconfig/jubatus-client.pc
+%{_includedir}/jubatus/client
+%{_includedir}/jubatus/client.hpp
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig


### PR DESCRIPTION
Refs #1150.

This introduces 2 changes:

* DEB package: now depends on OpenCV library.
* RPM package: separate plugins from main ``jubatus`` package.
  Users can now choose which plugins to be installed.

----

* Merge after #1150.  I'm still testing this PR in several systems.
* Need to update docs. (installation procedure)