### PR TITLE
clean up after installation and reduce number of layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM ubuntu:14.04
 MAINTAINER PFN & NTT <jubatus-team@googlegroups.com>
 
 # install the latest jubatus
-RUN echo "deb http://download.jubat.us/apt/ubuntu/trusty binary/" >> /etc/apt/sources.list.d/jubatus.list
-RUN apt-get -y update
-RUN apt-get --force-yes -y install jubatus
+RUN echo "deb http://download.jubat.us/apt/ubuntu/trusty binary/" >> /etc/apt/sources.list.d/jubatus.list && \
+    apt-get -y update && \
+    apt-get --force-yes -y install jubatus && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # set environment variables from /opt/jubatus/profile
 ENV JUBATUS_HOME /opt/jubatus


### PR DESCRIPTION
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/

> Minimize the number of layers

> In addition, cleaning up the apt cache and removing /var/lib/apt/lists helps keep the image size down. Since the RUN statement starts with apt-get update, the package cache will always be refreshed prior to apt-get install.

After applying this patch the image size reduced from 365.2 MB to 343 MB.