### PR TITLE
Disable strict version checking (fix #1179)

### DIFF
--- a/jubatus/server/framework/save_load.cpp
+++ b/jubatus/server/framework/save_load.cpp
@@ -183,16 +183,13 @@ void load_server(
   uint32_t jubatus_minor_read = read_big_endian<uint32_t>(&header_buf[20]);
   uint32_t jubatus_maintenance_read =
       read_big_endian<uint32_t>(&header_buf[24]);
-  if (jubatus_major_read != jubatus_version_major ||
-      jubatus_minor_read != jubatus_version_minor ||
-      jubatus_maintenance_read != jubatus_version_maintenance) {
+  if (jubatus_major_read != 1) {
     throw JUBATUS_EXCEPTION(
         core::common::exception::runtime_error(
-          "jubatus version mismatched: " +
+          "cannot load model file created before v1.0.0: " +
           lexical_cast<std::string>(jubatus_major_read) + "." +
           lexical_cast<std::string>(jubatus_minor_read) + "." +
-          lexical_cast<std::string>(jubatus_maintenance_read) +
-          ", expected (current) version: " JUBATUS_VERSION));
+          lexical_cast<std::string>(jubatus_maintenance_read)));
   }
   uint32_t crc32_expected = read_big_endian<uint32_t>(&header_buf[28]);
   uint64_t system_data_size = read_big_endian<uint64_t>(&header_buf[32]);


### PR DESCRIPTION
Fix #1179.

When loading old model, the following error message is displayed:

```
2017-03-21 11:55:25,433 20764 INFO  [server_base.cpp:60] starting load from /tmp/192.168.122.211_9199_classifier_foo.jubatus
2017-03-21 11:55:25,433 20764 FATAL [server_util.hpp:161] exception in main thread: jubatus::core::common::exception::runtime_error: cannot load model file created before v1.0.0: 0.8.9
    (#0) Source: ../jubatus/server/framework/save_load.cpp
    (#0) Line: 192
    (#0) Function: void jubatus::server::framework::load_server(std::istream&, jubatus::server::framework::server_base&, const string&, bool)
```