### PR TITLE
Show build status of travis-ci in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Jubatus
 =======
 
+.. image:: https://api.travis-ci.org/jubatus/jubatus.svg?branch=master
+    :target: https://api.travis-ci.org/jubatus/jubatus
+
 The Jubatus library is an online machine learning framework which runs in distributed environment.
 
 See http://jubat.us/ for details.


### PR DESCRIPTION
please see [here](https://github.com/kumagi/jubatus/blob/show-build-status-of-travis/README.rst).
Build status badge is good indicator of OSS. How about add it?