### PR TITLE
Revert "use same storage class for standalone and distributed mode (fix #469)"

### DIFF
--- a/jubatus/server/server/classifier_serv.cpp
+++ b/jubatus/server/server/classifier_serv.cpp
@@ -66,7 +66,8 @@ struct classifier_serv_config {
 
 shared_ptr<core::storage::storage_base> make_model(
     const framework::server_argv& arg) {
-  return core::storage::storage_factory::create_storage("local_mixture");
+  return core::storage::storage_factory::create_storage(
+      (arg.is_standalone()) ? "local" : "local_mixture");
 }
 
 }  // namespace

--- a/jubatus/server/server/regression_serv.cpp
+++ b/jubatus/server/server/regression_serv.cpp
@@ -61,7 +61,8 @@ struct regression_serv_config {
 
 shared_ptr<core::storage::storage_base> make_model(
     const framework::server_argv& arg) {
-  return core::storage::storage_factory::create_storage("local_mixture");
+  return core::storage::storage_factory::create_storage(
+      (arg.is_standalone()) ? "local" : "local_mixture");
 }
 
 }  // namespace


### PR DESCRIPTION
This reverts commit 26362610725c42190b7dbcd2fb3377d467424fee. Refs #1190