### PR TITLE
fix config comparision not working stably

### DIFF
--- a/jubatus/server/framework/save_load.cpp
+++ b/jubatus/server/framework/save_load.cpp
@@ -103,9 +103,7 @@ bool fwrite_helper(const char* buffer, size_t size, FILE* fp) {
  */
 bool compare_config(const std::string& left, const std::string& right) {
   using jubatus::util::text::json::json;
-  return
-      lexical_cast<std::string>(lexical_cast<json>(left)) ==
-      lexical_cast<std::string>(lexical_cast<json>(right));
+  return lexical_cast<json>(left) == lexical_cast<json>(right);
 }
 
 }  // namespace


### PR DESCRIPTION
Semantic comparision of config, which runs when loading a model to already-running server, was not working stably.

As `jubatus::util::text::json` is implemented using `unordered_map`, the serialized JSON string is not always the same for the same JSON data structure.
This PR fixes the issue by comparing config with `==` operator, which was introduced in https://github.com/jubatus/jubatus_core/pull/380, instead of comparing serialized JSON config string.

This issue was found during review of https://github.com/jubatus/jubakit/pull/83.