### PR TITLE
Feature/bulk add

### DIFF
--- a/jubatus/client/anomaly_client.hpp
+++ b/jubatus/client/anomaly_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.9.4-42-g70f7539/develop
+// This file is auto-generated from anomaly.idl(1.0.6-6-g2cf96c3) with jenerator version 0.9.4-42-g70f7539/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_ANOMALY_CLIENT_HPP_
@@ -30,6 +30,12 @@ class anomaly : public jubatus::client::common::client {
   id_with_score add(const jubatus::client::common::datum& row) {
     msgpack::rpc::future f = c_.call("add", name_, row);
     return f.get<id_with_score>();
+  }
+
+  std::vector<std::string> add_bulk(
+      const std::vector<jubatus::client::common::datum>& data) {
+    msgpack::rpc::future f = c_.call("add_bulk", name_, data);
+    return f.get<std::vector<std::string> >();
   }
 
   float update(const std::string& id,

--- a/jubatus/client/anomaly_types.hpp
+++ b/jubatus/client/anomaly_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.9.4-42-g70f7539/develop
+// This file is auto-generated from anomaly.idl(1.0.6-6-g2cf96c3) with jenerator version 0.9.4-42-g70f7539/develop
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_CLIENT_ANOMALY_TYPES_HPP_

--- a/jubatus/server/server/anomaly.idl
+++ b/jubatus/server/server/anomaly.idl
@@ -29,6 +29,10 @@ service anomaly {
   #@random #@nolock #@pass
   id_with_score add(0: datum row)
 
+  #- add points.
+  #@random #@nolock #@pass
+  list<string> add_bulk(0: list<datum> data)
+
   #- update a point.
   #@cht #@update #@pass
   float update(0: string id, 1: datum row)

--- a/jubatus/server/server/anomaly_client.hpp
+++ b/jubatus/server/server/anomaly_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.9.4-42-g70f7539/develop
+// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_CLIENT_HPP_
@@ -29,6 +29,12 @@ class anomaly : public jubatus::client::common::client {
   id_with_score add(const jubatus::core::fv_converter::datum& row) {
     msgpack::rpc::future f = c_.call("add", name_, row);
     return f.get<id_with_score>();
+  }
+
+  std::vector<std::string> add_bulk(
+      const std::vector<jubatus::core::fv_converter::datum>& data) {
+    msgpack::rpc::future f = c_.call("add_bulk", name_, data);
+    return f.get<std::vector<std::string> >();
   }
 
   float update(const std::string& id,

--- a/jubatus/server/server/anomaly_client.hpp
+++ b/jubatus/server/server/anomaly_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
+// This file is auto-generated from anomaly.idl(1.0.6-6-g2cf96c3) with jenerator version 0.9.4-42-g70f7539/master
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_CLIENT_HPP_

--- a/jubatus/server/server/anomaly_impl.cpp
+++ b/jubatus/server/server/anomaly_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
+// This file is auto-generated from anomaly.idl(1.0.6-6-g2cf96c3) with jenerator version 0.9.4-42-g70f7539/master
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/anomaly_impl.cpp
+++ b/jubatus/server/server/anomaly_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.9.4-42-g70f7539/develop
+// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -25,6 +25,10 @@ class anomaly_impl : public jubatus::server::common::mprpc::rpc_server {
     rpc_server::add<id_with_score(std::string,
         jubatus::core::fv_converter::datum)>("add", jubatus::util::lang::bind(
         &anomaly_impl::add, this, jubatus::util::lang::_2));
+    rpc_server::add<std::vector<std::string>(std::string,
+        std::vector<jubatus::core::fv_converter::datum>)>("add_bulk",
+        jubatus::util::lang::bind(&anomaly_impl::add_bulk, this,
+        jubatus::util::lang::_2));
     rpc_server::add<float(std::string, std::string,
         jubatus::core::fv_converter::datum)>("update",
         jubatus::util::lang::bind(&anomaly_impl::update, this,
@@ -62,6 +66,12 @@ class anomaly_impl : public jubatus::server::common::mprpc::rpc_server {
   id_with_score add(const jubatus::core::fv_converter::datum& row) {
     NOLOCK_(p_);
     return get_p()->add(row);
+  }
+
+  std::vector<std::string> add_bulk(
+      const std::vector<jubatus::core::fv_converter::datum>& data) {
+    NOLOCK_(p_);
+    return get_p()->add_bulk(data);
   }
 
   float update(const std::string& id,

--- a/jubatus/server/server/anomaly_proxy.cpp
+++ b/jubatus/server/server/anomaly_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.9.4-42-g70f7539/develop
+// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -23,6 +23,8 @@ int run_proxy(int argc, char* argv[]) {
         &jubatus::server::framework::all_and));
     k.register_async_random<id_with_score, jubatus::core::fv_converter::datum>(
         "add");
+    k.register_async_random<std::vector<std::string>,
+        std::vector<jubatus::core::fv_converter::datum> >("add_bulk");
     k.register_async_cht<2, float, jubatus::core::fv_converter::datum>("update",
         jubatus::util::lang::function<float(float, float)>(
         &jubatus::server::framework::pass<float>));

--- a/jubatus/server/server/anomaly_proxy.cpp
+++ b/jubatus/server/server/anomaly_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
+// This file is auto-generated from anomaly.idl(1.0.6-6-g2cf96c3) with jenerator version 0.9.4-42-g70f7539/master
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/jubatus/server/server/anomaly_serv.cpp
+++ b/jubatus/server/server/anomaly_serv.cpp
@@ -58,7 +58,7 @@ namespace server {
 namespace {
 
 struct anomaly_serv_config {
-  std::string method;
+  string method;
   // TODO(oda): we should use optional<jsonconfig::config> instead of
   //            jsonconfig::config ?
   core::common::jsonconfig::config parameter;
@@ -108,7 +108,7 @@ uint64_t anomaly_serv::user_data_version() const {
   return 1;  // should be inclemented when model data is modified
 }
 
-void anomaly_serv::set_config(const std::string& config) {
+void anomaly_serv::set_config(const string& config) {
   core::common::jsonconfig::config conf_root(lexical_cast<json>(config));
   anomaly_serv_config conf =
     core::common::jsonconfig::config_cast_check<anomaly_serv_config>(conf_root);
@@ -125,7 +125,7 @@ void anomaly_serv::set_config(const std::string& config) {
   }
 #endif
 
-  std::string my_id;
+  string my_id;
 #ifdef HAVE_ZOOKEEPER_H
   my_id = common::build_loc_str(argv().eth, argv().port);
 #endif
@@ -174,6 +174,21 @@ id_with_score anomaly_serv::add(const datum& data) {
 #endif
 }
 
+vector<string> anomaly_serv::add_bulk(
+    const vector<datum>& data) /* nolock!! */ {
+    check_set_config();
+    vector<pair<string, datum> > points;
+    vector<datum>::const_iterator iter = data.begin();
+    for (; iter < data.end(); ++iter) {
+      uint64_t id = idgen_->generate();
+      string id_str = lexical_cast<string>(id);
+      points.push_back(make_pair(id_str, *iter));
+    }
+    jubatus::util::concurrent::scoped_wlock lk(rw_mutex());
+    event_model_updated();
+    return anomaly_->add_bulk(points);
+}
+  
 id_with_score anomaly_serv::add_zk(const string&id_str, const datum& d) {
   vector<pair<string, int> > nodes;
   float score = 0;
@@ -295,7 +310,7 @@ float anomaly_serv::selective_update(
   }
 }
 
-bool anomaly_serv::load(const std::string& id) {
+bool anomaly_serv::load(const string& id) {
   if (server_base::load(id)) {
     reset_id_generator();
     return true;
@@ -303,7 +318,7 @@ bool anomaly_serv::load(const std::string& id) {
   return false;
 }
 
-void anomaly_serv::load_file(const std::string& path) {
+void anomaly_serv::load_file(const string& path) {
   server_base::load_file(path);
   reset_id_generator();
 }

--- a/jubatus/server/server/anomaly_serv.cpp
+++ b/jubatus/server/server/anomaly_serv.cpp
@@ -188,7 +188,7 @@ vector<string> anomaly_serv::add_bulk(
     event_model_updated();
     return anomaly_->add_bulk(points);
 }
-  
+
 id_with_score anomaly_serv::add_zk(const string&id_str, const datum& d) {
   vector<pair<string, int> > nodes;
   float score = 0;

--- a/jubatus/server/server/anomaly_serv.hpp
+++ b/jubatus/server/server/anomaly_serv.hpp
@@ -56,6 +56,9 @@ class anomaly_serv : public framework::server_base {
   bool clear_row(const std::string& id);
 
   id_with_score add(const core::fv_converter::datum& d);
+  std::vector<std::string> add_bulk(
+      const std::vector<jubatus::core::fv_converter::datum>& data) /* nolock!! */;
+
   float update(const std::string& id, const core::fv_converter::datum& d);
   float overwrite(const std::string& id, const core::fv_converter::datum& d);
 

--- a/jubatus/server/server/anomaly_serv.hpp
+++ b/jubatus/server/server/anomaly_serv.hpp
@@ -57,7 +57,7 @@ class anomaly_serv : public framework::server_base {
 
   id_with_score add(const core::fv_converter::datum& d);
   std::vector<std::string> add_bulk(
-      const std::vector<jubatus::core::fv_converter::datum>& data) /* nolock!! */;
+      const std::vector<jubatus::core::fv_converter::datum>& data);
 
   float update(const std::string& id, const core::fv_converter::datum& d);
   float overwrite(const std::string& id, const core::fv_converter::datum& d);

--- a/jubatus/server/server/anomaly_types.hpp
+++ b/jubatus/server/server/anomaly_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
+// This file is auto-generated from anomaly.idl(1.0.6-6-g2cf96c3) with jenerator version 0.9.4-42-g70f7539/master
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_TYPES_HPP_

--- a/jubatus/server/server/anomaly_types.hpp
+++ b/jubatus/server/server/anomaly_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from anomaly.idl(0.9.0-26-g051b301) with jenerator version 0.9.4-42-g70f7539/develop
+// This file is auto-generated from anomaly.idl with jenerator version 0.9.4-42-g70f7539/remotes/origin/feature/1100
 // *** DO NOT EDIT ***
 
 #ifndef JUBATUS_SERVER_SERVER_ANOMALY_TYPES_HPP_


### PR DESCRIPTION
related to jubatus/jubatus_core#391

add_bulk randomly choose a Jubatus Server and add data points to it.
Note that `add` API adds a point to 2 Jubatus Servers using CHT while `add_bulk` adds to 1 Jubatus Server because of performance.

A simple benchmark of `add` and `add_bulk` is [here](https://gist.github.com/TkrUdagawa/53585e563597780dec3502b0caf3d160)
